### PR TITLE
Add liquid field to window object instead of methods

### DIFF
--- a/waves/src/App.tsx
+++ b/waves/src/App.tsx
@@ -191,7 +191,7 @@ function App() {
     useEffect(() => {
         let callback = (_message: MessageEvent) => {};
         // @ts-ignore
-        if (!window.wallet_status) {
+        if (!window.liquid) {
             callback = async (message: MessageEvent) => {
                 debug("Received message: %s", message.data);
                 await reloadWalletStatus();

--- a/waves/src/wasmProxy.ts
+++ b/waves/src/wasmProxy.ts
@@ -38,44 +38,44 @@ export interface TradeSide {
 
 export async function getWalletStatus(): Promise<WalletStatus> {
     // @ts-ignore
-    if (typeof window.wallet_status === "undefined") {
+    if (typeof window.liquid === "undefined") {
         debug("wallet_status not found. CS not yet defined? ");
         return Promise.reject("wallet_status undefined");
     }
     // @ts-ignore
-    return await window.wallet_status();
+    return await window.liquid.wallet_status();
 }
 
 export async function makeSellCreateSwapPayload(
     btc: string,
 ): Promise<CreateSwapPayload> {
     // @ts-ignore
-    if (!window.get_sell_create_swap_payload) {
+    if (!window.liquid.get_sell_create_swap_payload) {
         return Promise.reject("get_sell_create_swap_payload undefined");
     }
     // @ts-ignore
-    return await window.get_sell_create_swap_payload(btc);
+    return await window.liquid.get_sell_create_swap_payload(btc);
 }
 
 export async function makeBuyCreateSwapPayload(
     usdt: string,
 ): Promise<CreateSwapPayload> {
     // @ts-ignore
-    if (!window.get_buy_create_swap_payload) {
+    if (!window.liquid.get_buy_create_swap_payload) {
         return Promise.reject("get_buy_create_swap_payload undefined");
     }
     // @ts-ignore
-    return await window.get_buy_create_swap_payload(usdt);
+    return await window.liquid.get_buy_create_swap_payload(usdt);
 }
 
 export async function signAndSend(
     transaction: string,
 ): Promise<string> {
     // @ts-ignore
-    if (!window.sign_and_send) {
+    if (!window.liquid.sign_and_send) {
         return Promise.reject("sign_and_send undefined");
     }
 
     // @ts-ignore
-    return await window.sign_and_send(transaction);
+    return await window.liquid.sign_and_send(transaction);
 }


### PR DESCRIPTION
For this to work we must use `&JsValue::from(liquid)` and not `&JsValue::from_serde(&liquid)` (see https://github.com/rustwasm/wasm-bindgen/issues/2493).