### PR TITLE
Update to later version of `rust-elements`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,8 +518,8 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elements"
-version = "0.15.0"
-source = "git+https://github.com/luckysori/rust-elements?branch=upstreaming-fun#512dca4236ad19cc7585e96050e7128ed9e9ba15"
+version = "0.16.0"
+source = "git+https://github.com/luckysori/rust-elements?branch=explicit-and-confidential-txouts#33c58da490241f83b31efdbbbeb8fa0ac24c60b6"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.9.6",
@@ -1888,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-zkp"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e6230311d09435352b06e2ed2e45f56c57cfe652ef87cb6818d6746eb4dbe2"
+checksum = "5e57b977141f57b224fc579c23dac5978b5f594281450fe8b5e2b6aa816d0fde"
 dependencies = [
  "bitcoin_hashes 0.9.6",
  "rand 0.6.5",
@@ -1901,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828abf66fbfb25cb471b2ff5a83864e27e6af8b1382345a9d4aab1afe47f5082"
+checksum = "b45a3c4e1291985397df9770f864ed88bd51ee684b13a384f49d2fedb29f86f0"
 dependencies = [
  "cc",
  "secp256k1-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ members = [
 ]
 
 [patch.crates-io]
-# Until https://github.com/ElementsProject/rust-elements/pull/70/ is merged
-elements = { git = "https://github.com/luckysori/rust-elements", branch = "upstreaming-fun" }
+# Until https://github.com/ElementsProject/rust-elements/pull/78 is merged
+elements = { git = "https://github.com/luckysori/rust-elements", branch = "explicit-and-confidential-txouts" }

--- a/bobtimus/Cargo.toml
+++ b/bobtimus/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 elements-harness = { path = "../elements-harness" }
 env_logger = "0.8"
 futures = { version = "0.3", default-features = false }

--- a/bobtimus/src/bin/bobtimus.rs
+++ b/bobtimus/src/bin/bobtimus.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bobtimus::{cli::StartCommand, http, kraken, Bobtimus};
 use elements::{
     bitcoin::secp256k1::Secp256k1,
-    secp256k1::rand::{rngs::StdRng, thread_rng, SeedableRng},
+    secp256k1_zkp::rand::{rngs::StdRng, thread_rng, SeedableRng},
 };
 use elements_harness::Client;
 use std::sync::Arc;

--- a/bobtimus/src/bin/fake_bobtimus.rs
+++ b/bobtimus/src/bin/fake_bobtimus.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bobtimus::{cli::StartCommand, fixed_rate, http, Bobtimus, LiquidUsdt};
 use elements::{
     bitcoin::{secp256k1::Secp256k1, Amount},
-    secp256k1::rand::{rngs::StdRng, thread_rng, SeedableRng},
+    secp256k1_zkp::rand::{rngs::StdRng, thread_rng, SeedableRng},
     Address,
 };
 use elements_harness::{elementd_rpc::ElementsRpc, Client};

--- a/bobtimus/src/http.rs
+++ b/bobtimus/src/http.rs
@@ -2,7 +2,7 @@ use crate::{problem, Bobtimus, CreateSwapPayload, LatestRate, RateSubscription};
 use anyhow::Context;
 use elements::{
     encode::serialize_hex,
-    secp256k1::rand::{CryptoRng, RngCore},
+    secp256k1_zkp::rand::{CryptoRng, RngCore},
 };
 use futures::{StreamExt, TryStreamExt};
 use rust_embed::RustEmbed;

--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -4,7 +4,7 @@ use elements::{
         secp256k1::{All, Secp256k1},
         Amount,
     },
-    secp256k1::{
+    secp256k1_zkp::{
         rand::{CryptoRng, RngCore},
         SecretKey,
     },
@@ -279,7 +279,7 @@ mod tests {
     use anyhow::{Context, Result};
     use elements::{
         bitcoin::{secp256k1::Secp256k1, Amount, Network, PrivateKey, PublicKey},
-        secp256k1::{rand::thread_rng, SecretKey, SECP256K1},
+        secp256k1_zkp::{rand::thread_rng, SecretKey, SECP256K1},
         sighash::SigHashCache,
         Address, AddressParams, OutPoint, Transaction, TxOut,
     };
@@ -375,7 +375,7 @@ mod tests {
             .unwrap();
 
         let transaction = swap::alice_finalize_transaction(transaction, {
-            let commitment = input_alice.1.into_confidential().unwrap().value;
+            let value = input_alice.1.value;
             move |mut tx| async move {
                 let input_index = tx
                     .input
@@ -384,13 +384,8 @@ mod tests {
                     .context("transaction does not contain input")?;
                 let mut cache = SigHashCache::new(&tx);
 
-                tx.input[input_index].witness.script_witness = sign_with_key(
-                    &SECP256K1,
-                    &mut cache,
-                    input_index,
-                    &fund_sk_alice,
-                    commitment.into(),
-                );
+                tx.input[input_index].witness.script_witness =
+                    sign_with_key(&SECP256K1, &mut cache, input_index, &fund_sk_alice, value);
 
                 Ok(tx)
             }
@@ -496,7 +491,7 @@ mod tests {
             .unwrap();
 
         let transaction = swap::alice_finalize_transaction(transaction, {
-            let commitment = input_alice.1.into_confidential().unwrap().value;
+            let value = input_alice.1.value;
             move |mut tx| async move {
                 let input_index = tx
                     .input
@@ -505,13 +500,8 @@ mod tests {
                     .context("transaction does not contain input")?;
                 let mut cache = SigHashCache::new(&tx);
 
-                tx.input[input_index].witness.script_witness = sign_with_key(
-                    &SECP256K1,
-                    &mut cache,
-                    input_index,
-                    &fund_sk_alice,
-                    commitment.into(),
-                );
+                tx.input[input_index].witness.script_witness =
+                    sign_with_key(&SECP256K1, &mut cache, input_index, &fund_sk_alice, value);
 
                 Ok(tx)
             }

--- a/coin_selection/Cargo.toml
+++ b/coin_selection/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 bdk = { version = "0.4", default-features = false }
-elements = "0.15"
+elements = "0.16"
 estimate_transaction_size = { path = "../estimate_transaction_size" }
 thiserror = "1"

--- a/covenants/Cargo.toml
+++ b/covenants/Cargo.toml
@@ -8,14 +8,15 @@ edition = "2018"
 anyhow = "1"
 bitcoin_hashes = "0.9.0"
 coin_selection = { path = "../coin_selection" }
-elements = "0.15"
+elements = "0.16"
 elements-harness = { path = "../elements-harness" }
 env_logger = "0.8.3"
 estimate_transaction_size = { path = "../estimate_transaction_size" }
 hex = "0.4"
 hmac = "0.10"
 log = "0.4"
-secp256k1-zkp = { version = "0.2", features = [ "global-context", "hashes" ] }
+# TODO: See if we can remove this direct dependency
+secp256k1-zkp = { version = "0.4", features = [ "global-context", "hashes" ] }
 sha2 = "0.9"
 testcontainers = "0.12"
 tokio = { version = "1", default-features = false, features = [ "macros", "rt", "time" ] }

--- a/covenants/src/stack_simulator.rs
+++ b/covenants/src/stack_simulator.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use bitcoin_hashes::Hash;
 use elements::{
     bitcoin::PublicKey,
-    secp256k1::{Message, Signature, SECP256K1},
+    secp256k1_zkp::{Message, Signature, SECP256K1},
     Script,
 };
 
@@ -121,7 +121,7 @@ mod test {
         bitcoin::{util::psbt::serialize::Serialize, Network, PrivateKey},
         opcodes::all::*,
         script::Builder,
-        secp256k1::{rand::thread_rng, SecretKey},
+        secp256k1_zkp::{rand::thread_rng, SecretKey},
     };
     use std::env;
 

--- a/elements-harness/Cargo.toml
+++ b/elements-harness/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 async-trait = "0.1"
 bitcoin_hashes = "0.9.0"
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 futures = "0.3.5"
 hex = "0.4.2"
 hmac = "0.10"

--- a/elements-harness/src/elementd_rpc.rs
+++ b/elements-harness/src/elementd_rpc.rs
@@ -4,7 +4,7 @@ use elements::{
     bitcoin::{Amount, PrivateKey},
     confidential::{Asset, Nonce, Value},
     encode::serialize_hex,
-    secp256k1::{SecretKey, Signature},
+    secp256k1_zkp::{SecretKey, Signature},
     Address, AssetId, OutPoint, Transaction, TxOut, TxOutWitness, Txid,
 };
 use serde::{Deserialize, Serialize};
@@ -268,9 +268,9 @@ impl Client {
                 .await
                 .context("cannot unblind raw source transaction")?;
             if unblinded_raw_tx.output[source_vout as usize]
-                .to_explicit()
-                .expect("explicit output")
                 .asset
+                .explicit()
+                .expect("explicit output")
                 == asset
             {
                 let source_txout = source_tx.output[input.previous_output.vout as usize].clone();

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = [ "cdylib", "rlib" ]
 anyhow = "1.0"
 conquer-once = "0.3"
 console_error_panic_hook = { version = "0.1.6" }
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 futures = "0.3"
 futures-timer = { version = "3", features = [ "wasm-bindgen" ] }
 js-sys = "0.3"

--- a/extension/background/Cargo.toml
+++ b/extension/background/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = [ "cdylib" ]
 anyhow = "1.0"
 conquer-once = "0.3"
 console_error_panic_hook = "0.1.6"
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 futures = "0.3"
 js-sys = "0.3"
 log = "0.4"

--- a/extension/in_page/Cargo.toml
+++ b/extension/in_page/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib" ]
 [dependencies]
 anyhow = "1.0"
 console_error_panic_hook = { version = "0.1.6", optional = true }
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 futures = "0.3"
 hex = "0.4"
 js-sys = "0.3"

--- a/extension/message_types/Cargo.toml
+++ b/extension/message_types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 coin_selection = { path = "../../coin_selection" }
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 js-sys = "0.3"
 rust_decimal = "1"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/extension/wallet_lib/Cargo.toml
+++ b/extension/wallet_lib/Cargo.toml
@@ -17,7 +17,7 @@ bdk = { version = "0.4", default-features = false }
 coin_selection = { path = "../../coin_selection" }
 conquer-once = "0.3"
 console_error_panic_hook = { version = "0.1.6", optional = true }
-elements = { version = "0.15", features = [ "serde-feature" ] }
+elements = { version = "0.16", features = [ "serde-feature" ] }
 estimate_transaction_size = { path = "../../estimate_transaction_size" }
 futures = "0.3"
 getrandom = { version = "0.1", features = [ "wasm-bindgen" ] }
@@ -45,7 +45,7 @@ wasm-bindgen-test = "0.3.13"
 [build-dependencies]
 anyhow = "1"
 conquer-once = "0.3"
-elements = { version = "0.15" }
+elements = { version = "0.16" }
 
 # By default wasm-opt is true which makes the build fail.
 [package.metadata.wasm-pack.profile.release]

--- a/extension/wallet_lib/src/wallet/create_new.rs
+++ b/extension/wallet_lib/src/wallet/create_new.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use elements::secp256k1::SecretKey;
+use elements::secp256k1_zkp::SecretKey;
 use futures::lock::Mutex;
 
 use crate::{

--- a/extension/wallet_lib/src/wallet/sign_and_send_swap_transaction.rs
+++ b/extension/wallet_lib/src/wallet/sign_and_send_swap_transaction.rs
@@ -3,7 +3,7 @@ use crate::{
     wallet::{current, get_txouts, Wallet},
 };
 use anyhow::{Context, Result};
-use elements::{encode::deserialize, secp256k1::SECP256K1, sighash::SigHashCache, Txid};
+use elements::{encode::deserialize, secp256k1_zkp::SECP256K1, sighash::SigHashCache, Txid};
 use futures::lock::Mutex;
 use swap::{alice_finalize_transaction, sign_with_key};
 
@@ -46,7 +46,7 @@ pub async fn sign_and_send_swap_transaction(
                     &mut cache,
                     index,
                     &wallet.secret_key,
-                    output.to_confidential().unwrap().value.into(),
+                    output.value,
                 );
 
                 (index, script_witness)

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-elements = "0.15"
+elements = "0.16"
 estimate_transaction_size = { path = "../estimate_transaction_size" }
 secp256k1 = { version = "0.20", features = [ "bitcoin_hashes", "rand" ] }
 serde = { version = "1", features = [ "derive" ] }

--- a/swap/tests/happy_path.rs
+++ b/swap/tests/happy_path.rs
@@ -7,7 +7,7 @@ use elements::{
     opcodes,
     script::Builder,
     sighash::SigHashCache,
-    Address, AddressParams, OutPoint, SigHashType, Transaction, TxIn, TxOut, Txid, UnblindedTxOut,
+    Address, AddressParams, OutPoint, SigHashType, Transaction, TxIn, TxOut, Txid,
 };
 use elements_harness::{elementd_rpc::ElementsRpc, Client, Elementsd};
 use secp256k1::{rand::thread_rng, Message, SecretKey, SECP256K1};
@@ -135,7 +135,7 @@ async fn collaborative_create_and_sign() {
         asset_id_lbtc,
         Amount::from_sat(1), // sats / vbyte
         {
-            let commitment_1 = input_bob.1.into_confidential().unwrap().value;
+            let commitment_1 = input_bob.1.value;
             move |mut tx| async move {
                 let input_index_1 = tx
                     .input
@@ -148,7 +148,7 @@ async fn collaborative_create_and_sign() {
                     &mut SigHashCache::new(&tx),
                     input_index_1,
                     &fund_sk_bob,
-                    commitment_1.into(),
+                    commitment_1,
                 );
 
                 Ok(tx)
@@ -159,7 +159,7 @@ async fn collaborative_create_and_sign() {
     .unwrap();
 
     let transaction = alice_finalize_transaction(transaction, {
-        let commitment = input_alice.1.into_confidential().unwrap().value;
+        let commitment = input_alice.1.value;
         move |mut tx| async move {
             let input_index = tx
                 .input
@@ -172,7 +172,7 @@ async fn collaborative_create_and_sign() {
                 &mut SigHashCache::new(&tx),
                 input_index,
                 &fund_sk_alice,
-                commitment.into(),
+                commitment,
             );
 
             Ok(tx)
@@ -215,31 +215,25 @@ async fn move_output_to_wallet(
     let previous_output_tx = client.get_raw_transaction(previous_output.txid).await?;
     let previous_output = previous_output_tx.output[previous_output.vout as usize].clone();
 
-    let txout = previous_output
-        .to_confidential()
-        .context("not a confidential txout")?;
+    let previous_output_secrets =
+        previous_output.unblind(SECP256K1, previous_output_blinding_sk)?;
 
-    let UnblindedTxOut {
-        asset: asset_id,
-        asset_blinding_factor: abf_in,
-        value_blinding_factor: vbf_in,
-        value: amount_in,
-    } = txout.unblind(SECP256K1, previous_output_blinding_sk)?;
-
+    let amount_in = previous_output_secrets.value;
     let fee = 900_000;
     let amount_out = Amount::from_sat(amount_in - fee);
 
     let move_address = client.get_new_address(None).await?;
 
-    let inputs = [(asset_id, amount_in, txout.asset, abf_in, vbf_in)];
+    let inputs = [(previous_output.asset, &previous_output_secrets)];
 
-    let output = TxOut::new_last_confidential(
+    let asset_id = previous_output_secrets.asset;
+    let (output, _, _) = TxOut::new_last_confidential(
         &mut thread_rng(),
         &SECP256K1,
         amount_out.as_sat(),
         move_address,
         asset_id,
-        &inputs,
+        &inputs[..],
         &[],
     )?;
 
@@ -274,7 +268,7 @@ async fn move_output_to_wallet(
         let sighash = SigHashCache::new(&tx).segwitv0_sighash(
             0,
             &script,
-            txout.value.into(),
+            previous_output.value,
             SigHashType::All,
         );
 


### PR DESCRIPTION
There's still a smaller patch dependency which allows us to unblind transaction outputs. Once https://github.com/ElementsProject/rust-elements/pull/78 is merged, we can remove it.

We expect `rust-elements` to support PSETs fully in the near future, which should allow us to simplify a lot of this code anyway. But updating the code was simple enough.