### PR TITLE
Add MacOS ci builds for wasm wallet tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,15 @@ jobs:
 
 
   wasm_wallet_test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [ x86_64-unknown-linux-gnu, x86_64-apple-darwin ]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -149,10 +157,16 @@ jobs:
             target
             ~/.cargo/bin
             ~/.cache/.wasm-pack
-          key: ubuntu-rust-${{ steps.toolchain.outputs.rustc_hash }}-wasm-wallet-cargo-and-target-directory-${{ hashFiles('Cargo.lock') }}-v1
+          key: ${{ matrix.os }}-rust-${{ steps.toolchain.outputs.rustc_hash }}-wasm-wallet-cargo-and-target-directory-${{ hashFiles('Cargo.lock') }}-v1
 
       - name: Install wasm-pack
         run: which wasm-pack || curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Set CC and AR vars for MacOs
+        if: contains(matrix.os, 'macos')
+        run: |
+          echo "CC=/usr/local/opt/llvm/bin/clang" >> $GITHUB_ENV
+          echo "AR=/usr/local/opt/llvm/bin/llvm-ar" >> $GITHUB_ENV
 
       - name: Extension wallet tests
         run: |
@@ -163,5 +177,5 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: wasm-wallet-test-binary
+          name: ${{ matrix.os }}-wasm-wallet-test-binary
           path: ./target/wasm32-unknown-unknown/debug/deps/wallet-*.wasm


### PR DESCRIPTION
We can add a MacOS ci build for the whole repository once we've removed the libraries (swap/covenants/etc). These modules use docker for their tests which is not available on MacOS. 

Note: LLVM 12 is already installed on MacOS (see [here](https://github.com/bonomat/droplet/runs/3074604513?check_suite_focus=true)), hence we only need to overwrite the environment variables.

CC: @rishflab / @thomaseizinger : this might be interesting for you. 