### PR TITLE
Deterministic e2e test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run test
         run: |
           yarn install
-          yarn run test
+          yarn run all-tests
 
       - name: Archive logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,7 @@ jobs:
           name: Logfiles
           path: |
             ./e2e_tests/bobtimus.log
-            ./e2e_tests/liquid.log
-            ./e2e_tests/electrs.log
-            ./e2e_tests/esplora.log
+            ./e2e_tests/screenshots
 
   build_test_workspace:
     strategy:

--- a/e2e_tests/.gitignore
+++ b/e2e_tests/.gitignore
@@ -1,6 +1,10 @@
 node_modules
-/nigiri/config/regtest/
-/nigiri/liquid-config/liquidregtest/
+
+# keep elements config
+!nigiri/liquid-config/elements.conf
+
+# ignore blockchain data
+nigiri/liquid-config/liquidregtest/*
 
 screenshots/*
 !screenshots/.gitkeep

--- a/e2e_tests/.gitignore
+++ b/e2e_tests/.gitignore
@@ -2,3 +2,5 @@ node_modules
 /nigiri/config/regtest/
 /nigiri/liquid-config/liquidregtest/
 
+screenshots/*
+!screenshots/.gitkeep

--- a/e2e_tests/e2e_test_setup.sh
+++ b/e2e_tests/e2e_test_setup.sh
@@ -12,7 +12,7 @@ while getopts "CS" o; do
             then
                 echo "Clearing docker compose data"
                 cd nigiri
-                docker compose down
+                docker-compose down
                 rm -rf liquid-config/liquidregtest
                 cd ..
             else
@@ -21,7 +21,7 @@ while getopts "CS" o; do
             ;;
         S)
             echo "Starting docker containers"
-            docker compose -f ./nigiri/docker-compose.yml up -d
+            docker-compose -f ./nigiri/docker-compose.yml up -d
             ;;
         *)
             usage

--- a/e2e_tests/e2e_test_setup.sh
+++ b/e2e_tests/e2e_test_setup.sh
@@ -75,3 +75,14 @@ echo "Bitcoin Asset ID: "$btc_asset_id
             --elementsd http://admin1:123@localhost:18884 \
             --usdt $usdt_asset_id > e2e_tests/bobtimus.log 2>&1 &
 )
+
+# give bobtimus time to start:
+
+sleep 5s
+
+# fund test wallets
+curl -POST  http://localhost:3030/api/faucet/el1qqfc6m8nrnrfpcsj9thg2df9jzpv4pwm4shm5wvn2untay2dmhhk4ut8j35jtd7jvqplx3gt9zth7ndtn6mcq68d03l4e7wqay -d {}
+curl -POST  http://localhost:3030/api/faucet/el1qq0zel5lg55nvhv9kkrq8gme8hnvp0lemuzcmu086dn2m8laxjgkewkhqnh8vxdnlp4cejs3925j0gu9n9krdgmqm89vku0kc8 -d {}
+curl -POST  http://localhost:3030/api/faucet/el1qqf09atu8jsmd25eclm8t5relx9q3x80yw3yncesd3ez2rgzy2pxkmamlcgrwlfa523rd4vjmcg4anyv2w89kk74k5p0af0pj5 -d {}
+curl -POST  http://localhost:3030/api/faucet/el1qqgupeqadsckv095dr7u90ukn3nsfs4gayfl3746kaf6l2nn0wrs8e5s4943wa0ven87ggpk9qgsdqz6779mgsj0783d9hau0d -d {}
+curl -POST  http://localhost:3030/api/faucet/el1qqfahtc82zq03wcq6t2hwys5azxp5l5pggpsxq7f8h5jfpq0waced0tg6s9v0avhsam03ecyycdrgw4gzcsackynfpjmfd5l6d -d {}

--- a/e2e_tests/e2e_test_setup.sh
+++ b/e2e_tests/e2e_test_setup.sh
@@ -81,8 +81,12 @@ echo "Bitcoin Asset ID: "$btc_asset_id
 sleep 5s
 
 # fund test wallets
-curl -POST  http://localhost:3030/api/faucet/el1qqfc6m8nrnrfpcsj9thg2df9jzpv4pwm4shm5wvn2untay2dmhhk4ut8j35jtd7jvqplx3gt9zth7ndtn6mcq68d03l4e7wqay -d {}
+
+# wallet for borrow.test.ts
 curl -POST  http://localhost:3030/api/faucet/el1qq0zel5lg55nvhv9kkrq8gme8hnvp0lemuzcmu086dn2m8laxjgkewkhqnh8vxdnlp4cejs3925j0gu9n9krdgmqm89vku0kc8 -d {}
+# wallet for unlock_wallet.test.ts
 curl -POST  http://localhost:3030/api/faucet/el1qqf09atu8jsmd25eclm8t5relx9q3x80yw3yncesd3ez2rgzy2pxkmamlcgrwlfa523rd4vjmcg4anyv2w89kk74k5p0af0pj5 -d {}
+# wallet for usdt-btc_buy.test.ts
 curl -POST  http://localhost:3030/api/faucet/el1qqgupeqadsckv095dr7u90ukn3nsfs4gayfl3746kaf6l2nn0wrs8e5s4943wa0ven87ggpk9qgsdqz6779mgsj0783d9hau0d -d {}
+# wallet for usdt-btc_sell.test.ts
 curl -POST  http://localhost:3030/api/faucet/el1qqfahtc82zq03wcq6t2hwys5azxp5l5pggpsxq7f8h5jfpq0waced0tg6s9v0avhsam03ecyycdrgw4gzcsackynfpjmfd5l6d -d {}

--- a/e2e_tests/nigiri/docker-compose.yml
+++ b/e2e_tests/nigiri/docker-compose.yml
@@ -1,0 +1,68 @@
+version: '3.9'
+services:
+  liquid:
+    image: vulpemventures/liquid:latest
+    ports:
+      - 18884:18884
+      - 18886:18886
+    volumes:
+      - ./liquid-config/:/config
+    restart: unless-stopped
+  electrs-liquid:
+    image: vulpemventures/electrs-liquid:latest
+    entrypoint:
+      - /build/electrs
+    command:
+      - -vvvv
+      - --parent-network
+      - regtest
+      - --network
+      - liquidregtest
+      - --daemon-dir
+      - /config
+      - --daemon-rpc-addr
+      - liquid:18884
+      - --cookie
+      - admin1:123
+      - --http-addr
+      - 0.0.0.0:3002
+      - --electrum-rpc-addr
+      - 0.0.0.0:60401
+      - --cors
+      - "*"
+    links:
+      - liquid
+    depends_on:
+      - liquid
+    ports:
+      - 50401:60401
+      - 3012:3002
+    volumes:
+      - ./liquid-config/:/config
+    restart: unless-stopped
+  chopsticks-liquid:
+    image: vulpemventures/nigiri-chopsticks:latest
+    command:
+      - --use-faucet
+      - --use-mining
+      - --use-logger
+      - --rpc-addr
+      - liquid:18884
+      - --electrs-addr
+      - electrs-liquid:3002
+      - --addr
+      - 0.0.0.0:3000
+      - --chain
+      - liquid
+    links:
+      - electrs-liquid
+      - liquid
+    depends_on:
+      - electrs-liquid
+    ports:
+      - 3001:3000
+    restart: unless-stopped
+
+networks:
+  default:
+    name: nigiri

--- a/e2e_tests/nigiri/liquid-config/elements.conf
+++ b/e2e_tests/nigiri/liquid-config/elements.conf
@@ -1,0 +1,14 @@
+chain=liquidregtest
+listen=1
+txindex=1
+
+[liquidregtest]
+port=18886
+rpcport=18884
+rpcuser=admin1
+rpcpassword=123
+rpcallowip=0.0.0.0/0
+rpcbind=0.0.0.0
+
+validatepegin=0
+initialfreecoins=2100000000000000

--- a/e2e_tests/package.json
+++ b/e2e_tests/package.json
@@ -3,7 +3,13 @@
   "name": "e2e_tests",
   "version": "0.0.1",
   "scripts": {
-    "test": "DEBUG=e2e-* jest -runInBand"
+    "create-test": "DEBUG=e2e-* jest -t 'create'",
+    "unlock-test": "DEBUG=e2e-* jest -t 'unlock'",
+    "buy-test": "DEBUG=e2e-* jest -t 'buy'",
+    "sell-test": "DEBUG=e2e-* jest -t 'sell'",
+    "borrow-test": "DEBUG=e2e-* jest -t 'borrow'",
+    "all-tests": "yarn run create-test && yarn run unlock-test && yarn run buy-test && yarn run sell-test && yarn run borrow-test",
+    "all-tests-browser": "BROWSER=true yarn run all-tests"
   },
   "dependencies": {
     "@types/debug": "4.1.6",

--- a/e2e_tests/readme.md
+++ b/e2e_tests/readme.md
@@ -1,0 +1,60 @@
+Writing e2e tests is hard. Here are some hints on how to make them as reliable as possible:
+
+- run tests sequentially: in order to rule out random errors, it is recommended to run all tests sequentially.
+  For each test we have a separate run target in our package.json.
+  If you want to run all tests in sequence, run:
+
+```bash
+yarn run all-tests
+```
+
+- tests run in headless mode by default.
+  If you want to run them in the browser and watch for errors, export the environment variable: `BROWSER=true` before running the tests.
+  If you want to run all tests in the browser in sequence, run:
+
+```bash
+yarn run all-tests-browser
+```
+
+- each test should use its own wallet.
+  The setup for this is a bit cumbersome but below is an explanation which can help you to set things up:
+
+To generate a wallet run the `create wallet test` with the following command:
+
+```bash
+DEBUG=setup yarn jest -t 'create'
+yarn run
+```
+
+this will print your wallet data.
+With this data you can pre-create a wallet like this which you can use in your own test.
+
+```javascript
+const setupTestingWallet = async (
+    driver: WebDriver,
+    extensionTitle: string,
+) => {
+    await switchToWindow(driver, extensionTitle);
+
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.wallets','demo');",
+    );
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.password','$rscrypt$0$DwgB$QmUeLBayg1NxXuMCMmot3Q==$Ogoo7ALW3gkqInRVb6QK/0RrJiQmxzGXpdwdRkl3Ah4=$');",
+    );
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.xprv','8f17fed72c43e5d436fbfd8b185a9cca7f7174d5417750202870d6cecf48528f$75e519b159436a43089420ffedd882338dad57df7ee417af25e60ed06822c61f6ff061a54f046c96e42132cdac28db796d4fc900dcfbee73aeb9cd18d16af3b6c2aab96d04e29916eb3fca2c72d3ca4fc6fa88757dc719dbc87dcef6a8062864d3c70e7bdbedc7a89348a44351182f3211b74a3ad6ebd371b391366a78bd88');",
+    );
+
+    return "el1qqfqjvmhpv0lkhzjl8a5nqhz07s23lx84ug9fyj35l8rvm7vf4adqvh3axdppyl8aqmsu46p2qf8zj4zqmq8lxhh5h0gsxl7ym";
+};
+```
+
+Make sure to extend the `e2e_test_setup.sh` so that your wallet has funding when starting the test.
+As a rule of thumb: we don't want to have to call the faucet during our tests as this will add an additional source of randomness.
+
+```bash
+curl -POST  http://localhost:3030/api/faucet/el1qqfqjvmhpv0lkhzjl8a5nqhz07s23lx84ug9fyj35l8rvm7vf4adqvh3axdppyl8aqmsu46p2qf8zj4zqmq8lxhh5h0gsxl7ym -d {} > /dev/null
+```
+
+Once this is all done, testing should be fun 🥳.

--- a/e2e_tests/src/borrow.test.ts
+++ b/e2e_tests/src/borrow.test.ts
@@ -1,25 +1,17 @@
 import Debug from "debug";
-import { until } from "selenium-webdriver";
-import {
-    faucet,
-    getElementById,
-    setupBrowserWithExtension,
-    setupTestingWallet,
-    switchToWindow,
-    unlockWallet,
-} from "./utils";
+import { until, WebDriver } from "selenium-webdriver";
+import { getElementById, setupBrowserWithExtension, switchToWindow, unlockWallet } from "./utils";
 
-describe("e2e tests", () => {
+describe("borrow test", () => {
     const webAppUrl = "http://localhost:3030";
 
     let driver;
     let extensionId: string;
     let webAppTitle: string;
     let extensionTitle: string;
+    const debug = Debug("e2e-borrow");
 
     beforeAll(async () => {
-        const debug = Debug("e2e-setup");
-
         let { driver: d, extensionId: eId, extensionTitle: eTitle, webAppTitle: wTitle } =
             await setupBrowserWithExtension(webAppUrl);
         driver = d;
@@ -30,9 +22,6 @@ describe("e2e tests", () => {
         debug("Setting up testing wallet");
         let address = await setupTestingWallet(driver, extensionTitle);
 
-        debug("Funding testing wallet");
-        await faucet(address);
-
         debug("Unlocking wallet");
         await unlockWallet(driver, extensionTitle);
     }, 20000);
@@ -41,89 +30,7 @@ describe("e2e tests", () => {
         await driver.quit();
     });
 
-    test("sell swap", async () => {
-        const debug = Debug("e2e-sell");
-
-        await switchToWindow(driver, webAppTitle);
-        await driver.navigate().refresh();
-
-        debug("Setting L-BTC amount");
-        let btcAmountInput = await getElementById(driver, "//div[@data-cy='data-cy-L-BTC-amount-input']//input");
-        await btcAmountInput.clear();
-        await btcAmountInput.sendKeys("0.4");
-
-        debug("Clicking on swap button");
-        let swapButton = await getElementById(driver, "//button[@data-cy='data-cy-swap-button']");
-        await driver.wait(until.elementIsEnabled(swapButton), 20000);
-        await swapButton.click();
-
-        await switchToWindow(driver, extensionTitle);
-
-        // TODO: Remove when automatic pop-up refresh
-        // happens based on signing state
-        await new Promise(r => setTimeout(r, 10_000));
-        await driver.navigate().refresh();
-
-        debug("Signing and sending transaction");
-        let signTransactionButton = await getElementById(driver, "//button[@data-cy='data-cy-sign-and-send-button']");
-        await signTransactionButton.click();
-
-        await switchToWindow(driver, webAppTitle);
-
-        await driver.sleep(2000);
-        let url = await driver.getCurrentUrl();
-        expect(url).toContain("/swapped/");
-        debug("Swap successful");
-    }, 40000);
-
-    test("buy swap", async () => {
-        const debug = Debug("e2e-buy");
-
-        await switchToWindow(driver, webAppTitle);
-        await driver.get(webAppUrl);
-
-        debug("Switching assets");
-        let switchAssetTypesButton = await getElementById(
-            driver,
-            "//button[@data-cy='data-cy-exchange-asset-types-button']",
-        );
-        await switchAssetTypesButton.click();
-
-        debug("Setting L-USDt amount");
-        let usdtAmountInput = await getElementById(driver, "//div[@data-cy='data-cy-USDt-amount-input']//input");
-        await usdtAmountInput.clear();
-        await usdtAmountInput.sendKeys("5000.0");
-
-        debug("Clicking on swap button");
-        let swapButton = await getElementById(driver, "//button[@data-cy='data-cy-swap-button']");
-        await driver.wait(until.elementIsEnabled(swapButton), 20000);
-        await swapButton.click();
-
-        await switchToWindow(driver, extensionTitle);
-
-        // TODO: Remove when automatic pop-up refresh
-        // happens based on signing state
-        await new Promise(r => setTimeout(r, 10_000));
-        await driver.navigate().refresh();
-
-        debug("Signing and sending transaction");
-        let signTransactionButton = await getElementById(
-            driver,
-            "//button[@data-cy='data-cy-sign-and-send-button']",
-        );
-        await signTransactionButton.click();
-
-        await switchToWindow(driver, webAppTitle);
-
-        await driver.sleep(2000);
-        let url = await driver.getCurrentUrl();
-        expect(url).toContain("/swapped/");
-        debug("Swap successful");
-    }, 40000);
-
     test("borrow", async () => {
-        const debug = Debug("e2e-borrow");
-
         debug("Navigating to borrow page");
         await switchToWindow(driver, webAppTitle);
         await driver.get(`${webAppUrl}/borrow`);
@@ -135,8 +42,6 @@ describe("e2e tests", () => {
         );
         await principalAmountInput.clear();
 
-        // TODO: Careful changing this value until we fix a bug with the
-        // computed collateral amount having too many decimal places
         await principalAmountInput.sendKeys("3000");
 
         debug("Clicking on take loan button");
@@ -197,3 +102,20 @@ describe("e2e tests", () => {
         debug("Repayment successful");
     }, 40000);
 });
+
+// set testing wallet.
+// seed words are: `town exhaust stamp palace grab crater jacket industry day dwarf various jacket frozen cricket issue bubble advance zebra raven ivory label capital strong uphold`
+// wallet password is: `foo`.
+const setupTestingWallet = async (driver: WebDriver, extensionTitle: string) => {
+    await switchToWindow(driver, extensionTitle);
+
+    await driver.executeScript("return window.localStorage.setItem('wallets','demo');");
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.password','$rscrypt$0$DwgB$7BzKF9q5Hg/nILiT0M7X+Q==$xh7ImFcmYCrBdqsEj2jBaOZHPyg0hnWCkIUICcLmJuQ=$');",
+    );
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.xprv','733889793b645460290a16b9d19166b761fb849154e5485848c6fccc6b760442$48c3859aae6a8480447065703096e5dfde215dbf3e80306a05ceaa262d1b9b52881390a22bc4411a2a885e704f45bede9c0ec74866292c9ad86a8156ff4d16dfcdb72b8e8c481392fd32bc181b0b4ff376651ba6474feb60a2f05a638671037e4efaf680209deed0ae183fba65bb437725a9509ae9ee07f06a1ee3312c33c7');",
+    );
+
+    return "el1qq0zel5lg55nvhv9kkrq8gme8hnvp0lemuzcmu086dn2m8laxjgkewkhqnh8vxdnlp4cejs3925j0gu9n9krdgmqm89vku0kc8";
+};

--- a/e2e_tests/src/create_wallet.test.ts
+++ b/e2e_tests/src/create_wallet.test.ts
@@ -74,9 +74,7 @@ describe("create wallet", () => {
         debug("Getting wallet address");
         let addressField = await getElementById(driver, "//p[@data-cy='data-cy-wallet-address-text-field']");
         let address = await addressField.getText();
-        debug(`Address found: ${address}`);
 
-        // TODO: re-enable faucet again
         let url = `${webAppUrl}/api/faucet/${address}`;
         debug("Calling faucet: %s", url);
         let response = await fetch(url, {
@@ -86,13 +84,34 @@ describe("create wallet", () => {
         let body = await response.text();
         debug("Faucet response: %s", body);
 
-        // TODO: Remove when automatic balance refreshing is
-        // implemented
+        // TODO: Remove when automatic balance refreshing is implemented
         await new Promise(r => setTimeout(r, 10_000));
         await driver.navigate().refresh();
 
         debug("Waiting for balance update");
         let btcAmount = await getElementById(driver, "//p[@data-cy='data-cy-L-BTC-balance-text-field']", 20_000);
         debug("Found L-BTC amount: %s", await btcAmount.getText());
+
+        let wallets = await driver.executeScript(
+            "return window.localStorage.getItem('wallets')",
+        );
+        let pwd = await driver.executeScript(
+            "return window.localStorage.getItem('wallets.demo.password')",
+        );
+        let xprv = await driver.executeScript(
+            "return window.localStorage.getItem('wallets.demo.xprv')",
+        );
+
+        let setup_logger = Debug("setup");
+        setup_logger(
+            `await driver.executeScript("return window.localStorage.setItem('wallets.demo.wallets','${wallets}');",);`,
+        );
+        setup_logger(
+            `await driver.executeScript("return window.localStorage.setItem('wallets.demo.password','${pwd}');",);`,
+        );
+        setup_logger(
+            `await driver.executeScript("return window.localStorage.setItem('wallets.demo.xprv','${xprv}');",);`,
+        );
+        setup_logger(`Address: '${address}'`);
     }, 30_000);
 });

--- a/e2e_tests/src/create_wallet.test.ts
+++ b/e2e_tests/src/create_wallet.test.ts
@@ -8,7 +8,7 @@ const getElementById = async (driver, xpath, timeout = 4000) => {
     return await driver.wait(until.elementIsVisible(el), timeout);
 };
 
-describe("webdriver", () => {
+describe("create wallet", () => {
     const webAppUrl = "http://localhost:3030";
 
     let driver;
@@ -39,11 +39,14 @@ describe("webdriver", () => {
         let step1 = await getElementById(driver, "//button[@data-cy='data-cy-create-wallet-step-1']");
         await step1.click();
 
-        let mnemonic =
-            "globe favorite camp draw action kid soul junk space soda genre vague name brisk female circle equal fix decade gloom elbow address genius noodle";
+        let refreshMnemonicButton = await getElementById(
+            driver,
+            "//button[@data-cy='data-cy-create-wallet-generate-mnemonic']",
+        );
+        await refreshMnemonicButton.click();
 
         let mnemonicInput = await getElementById(driver, "//textarea[@data-cy='data-cy-create-wallet-mnemonic-input']");
-        await mnemonicInput.sendKeys(mnemonic);
+        let mnemonic = mnemonicInput.getText();
 
         let checkBox = await getElementById(driver, "//label[@data-cy='data-cy-create-wallet-checkbox-input']");
         await checkBox.click();

--- a/e2e_tests/src/unlock_wallet.test.ts
+++ b/e2e_tests/src/unlock_wallet.test.ts
@@ -1,7 +1,8 @@
 import Debug from "debug";
-import { getElementById, setupBrowserWithExtension, setupTestingWallet, switchToWindow, unlockWallet } from "./utils";
+import { WebDriver } from "selenium-webdriver";
+import { getElementById, setupBrowserWithExtension, switchToWindow, unlockWallet } from "./utils";
 
-describe("e2e tests", () => {
+describe("unlock wallet test", () => {
     const webAppUrl = "http://localhost:3030";
 
     let driver;
@@ -45,3 +46,20 @@ describe("e2e tests", () => {
         );
     }, 40000);
 });
+
+// set testing wallet.
+// seed words are: `globe favorite camp draw action kid soul junk space soda genre vague name brisk female circle equal fix decade gloom elbow address genius noodle`
+// wallet password is: `foo`.
+const setupTestingWallet = async (driver: WebDriver, extensionTitle: string) => {
+    await switchToWindow(driver, extensionTitle);
+
+    await driver.executeScript("return window.localStorage.setItem('wallets','demo');");
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.password','$rscrypt$0$DwgB$brb7JqhPEJbIxXOu/Jn3Aw==$8eWWdvAarl6IuOjViqAZuqhq05aD/YBjTAtioqtoC9U=$');",
+    );
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.xprv','4b83ff6937ce2650354d02d9c7f6d9b828824c1dbe4d0795b3b14d9c9042dbca$0c130f39ada0ec0e9e0e2a2af91815f7e77f8ed64481467f19e42bcdfeaf88af2d10df9e9143223b71e053f67fad830ec102c7e977bd646cd1dec3a2718c97dc7e98cd349c7a3c2147f78c9b8b6436f68b96e2bf73f11ca496483175ad5dfa577d1efb40827455b05e3c51f9745ed8d4726d49f4a54470073efea876815f25');",
+    );
+
+    return "el1qqf09atu8jsmd25eclm8t5relx9q3x80yw3yncesd3ez2rgzy2pxkmamlcgrwlfa523rd4vjmcg4anyv2w89kk74k5p0af0pj5";
+};

--- a/e2e_tests/src/usdt-btc_buy.test.ts
+++ b/e2e_tests/src/usdt-btc_buy.test.ts
@@ -1,0 +1,92 @@
+import Debug from "debug";
+import { until, WebDriver } from "selenium-webdriver";
+import { getElementById, setupBrowserWithExtension, switchToWindow, unlockWallet } from "./utils";
+
+describe("buy usdt/btc", () => {
+    const webAppUrl = "http://localhost:3030";
+
+    let driver;
+    let extensionId: string;
+    let webAppTitle: string;
+    let extensionTitle: string;
+    const debug = Debug("e2e-usdt-btc-buy");
+
+    beforeAll(async () => {
+        let { driver: d, extensionId: eId, extensionTitle: eTitle, webAppTitle: wTitle } =
+            await setupBrowserWithExtension(webAppUrl);
+        driver = d;
+        extensionId = eId;
+        extensionTitle = eTitle;
+        webAppTitle = wTitle;
+
+        debug("Setting up testing wallet");
+        let address = await setupTestingWallet(driver, extensionTitle);
+
+        debug("Unlocking wallet");
+        await unlockWallet(driver, extensionTitle);
+    }, 20000);
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test("buy swap", async () => {
+        await switchToWindow(driver, webAppTitle);
+        await driver.get(webAppUrl);
+
+        debug("Switching assets");
+        let switchAssetTypesButton = await getElementById(
+            driver,
+            "//button[@data-cy='data-cy-exchange-asset-types-button']",
+        );
+        await switchAssetTypesButton.click();
+
+        debug("Setting L-USDt amount");
+        let usdtAmountInput = await getElementById(driver, "//div[@data-cy='data-cy-USDt-amount-input']//input");
+        await usdtAmountInput.clear();
+        await usdtAmountInput.sendKeys("5000.0");
+
+        debug("Clicking on swap button");
+        let swapButton = await getElementById(driver, "//button[@data-cy='data-cy-swap-button']");
+        await driver.wait(until.elementIsEnabled(swapButton), 20000);
+        await swapButton.click();
+
+        await switchToWindow(driver, extensionTitle);
+
+        // TODO: Remove when automatic pop-up refresh
+        // happens based on signing state
+        await new Promise(r => setTimeout(r, 10_000));
+        await driver.navigate().refresh();
+
+        debug("Signing and sending transaction");
+        let signTransactionButton = await getElementById(
+            driver,
+            "//button[@data-cy='data-cy-sign-and-send-button']",
+        );
+        await signTransactionButton.click();
+
+        await switchToWindow(driver, webAppTitle);
+
+        await driver.sleep(2000);
+        let url = await driver.getCurrentUrl();
+        expect(url).toContain("/swapped/");
+        debug("Swap successful");
+    }, 40000);
+});
+
+// set testing wallet.
+// seed words are: `crucial pizza enhance learn banner family scrub save gas earn carpet bottom carbon cost scatter sign item dash magic balcony income cement option awkward`
+// wallet password is: `foo`.
+const setupTestingWallet = async (driver: WebDriver, extensionTitle: string) => {
+    await switchToWindow(driver, extensionTitle);
+
+    await driver.executeScript("return window.localStorage.setItem('wallets','demo');");
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.password','$rscrypt$0$DwgB$M3qALv1UBJhZdcduTXndIA==$Cn3O/TcSLYHyNlOrDAee7pPqKR0jgIXicUfSZPfcxrM=$');",
+    );
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.xprv','1073c5ea651a37d956b7062dbb711656655f9033df9094c2dc29b6d07ab8fa82$4529591215f662c22c5f99347110bfcf4e0b9221a31694c46d16ccc5260b288b1538a6a209d3410d048fac92d77f09eebd7a2e1db5fd4d6bcd49618fe755a1712c739822f63394ca38019225c51e40498fa49136a7e5161a51c3056e0092d7ba7681657e345be05c6da211a7d7442892f13237f7968f93d1b3f5883f0bfdf2');",
+    );
+
+    return "el1qqgupeqadsckv095dr7u90ukn3nsfs4gayfl3746kaf6l2nn0wrs8e5s4943wa0ven87ggpk9qgsdqz6779mgsj0783d9hau0d";
+};

--- a/e2e_tests/src/usdt-btc_sell.test.ts
+++ b/e2e_tests/src/usdt-btc_sell.test.ts
@@ -1,0 +1,83 @@
+import Debug from "debug";
+import { until, WebDriver } from "selenium-webdriver";
+import { getElementById, setupBrowserWithExtension, switchToWindow, unlockWallet } from "./utils";
+
+describe("sell usdt/btc", () => {
+    const webAppUrl = "http://localhost:3030";
+
+    let driver;
+    let extensionId: string;
+    let webAppTitle: string;
+    let extensionTitle: string;
+
+    const debug = Debug("e2e-usdt-btc-sell");
+
+    beforeAll(async () => {
+        let { driver: d, extensionId: eId, extensionTitle: eTitle, webAppTitle: wTitle } =
+            await setupBrowserWithExtension(webAppUrl);
+        driver = d;
+        extensionId = eId;
+        extensionTitle = eTitle;
+        webAppTitle = wTitle;
+
+        debug("Setting up testing wallet");
+        let address = await setupTestingWallet(driver, extensionTitle);
+
+        debug("Unlocking wallet");
+        await unlockWallet(driver, extensionTitle);
+    }, 20000);
+
+    afterAll(async () => {
+        await driver.quit();
+    });
+
+    test("sell swap", async () => {
+        await switchToWindow(driver, webAppTitle);
+        await driver.navigate().refresh();
+
+        debug("Setting L-BTC amount");
+        let btcAmountInput = await getElementById(driver, "//div[@data-cy='data-cy-L-BTC-amount-input']//input");
+        await btcAmountInput.clear();
+        await btcAmountInput.sendKeys("0.4");
+
+        debug("Clicking on swap button");
+        let swapButton = await getElementById(driver, "//button[@data-cy='data-cy-swap-button']");
+        await driver.wait(until.elementIsEnabled(swapButton), 20000);
+        await swapButton.click();
+
+        await switchToWindow(driver, extensionTitle);
+
+        // TODO: Remove when automatic pop-up refresh
+        // happens based on signing state
+        await new Promise(r => setTimeout(r, 10_000));
+        await driver.navigate().refresh();
+
+        debug("Signing and sending transaction");
+        let signTransactionButton = await getElementById(driver, "//button[@data-cy='data-cy-sign-and-send-button']");
+        await signTransactionButton.click();
+
+        await switchToWindow(driver, webAppTitle);
+
+        await driver.sleep(2000);
+        let url = await driver.getCurrentUrl();
+        expect(url).toContain("/swapped/");
+        debug("Swap successful");
+    }, 40000);
+});
+
+// set testing wallet.
+// seed words are: `strike sound divide secret upset crime search trick castle inhale trouble approve filter bonus good real token electric rebuild brand pupil amount path taste`
+// wallet password is: `foo`.
+const setupTestingWallet = async (driver: WebDriver, extensionTitle: string) => {
+    await switchToWindow(driver, extensionTitle);
+
+    await driver.executeScript("return window.localStorage.setItem('wallets','demo');");
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.password','$rscrypt$0$DwgB$QLDYJMgUIYi3/8vSRGiiNw==$N5F/psorzkxIhjNn+ZjmMHbUwy/dXB78v1m/TEe2O4Y=$');",
+    );
+    await driver.executeScript(
+        "return window.localStorage.setItem('wallets.demo.xprv','663d02eacee85af99d1a11672637f18fe1c8e6e545aab835735fe5b59c9f3786$677a6dee6e7f94539a5273ff560cd62b5553e641bd141a7a0d52f2731b4aa7f3aa10ba3661129ed2e32c1b3a3e5b9116f20bc347917bceb7bd07f93534071a0910f3f0b4814e9640ff80e16834c5893fbf3ce84427e455a9f319861a7b370f092bbc28776be7812056ee068dc733e6f952a0ae22489b6b71d34ba39570aa54');",
+    );
+
+    return "el1qqfahtc82zq03wcq6t2hwys5azxp5l5pggpsxq7f8h5jfpq0waced0tg6s9v0avhsam03ecyycdrgw4gzcsackynfpjmfd5l6d";
+};

--- a/e2e_tests/src/utils.ts
+++ b/e2e_tests/src/utils.ts
@@ -20,7 +20,10 @@ const getElementById = async (driver, xpath, timeout = 4000) => {
 
 const setupBrowserWithExtension = async (webAppUrl: string) => {
     const service = new firefox.ServiceBuilder(firefoxPath);
-    const options = new firefox.Options().headless();
+    let options = new firefox.Options();
+    if (!process.env.BROWSER) {
+        options = options.headless();
+    }
 
     // it is of type firefox.Driver but typescript does not allow us to cast it
     // @ts-ignore
@@ -62,32 +65,6 @@ const setupBrowserWithExtension = async (webAppUrl: string) => {
     };
 };
 
-// set testing wallet.
-// seed words are: `globe favorite camp draw action kid soul junk space soda genre vague name brisk female circle equal fix decade gloom elbow address genius noodle`
-// wallet password is: `foo`.
-// address is: `el1qqf09atu8jsmd25eclm8t5relx9q3x80yw3yncesd3ez2rgzy2pxkmamlcgrwlfa523rd4vjmcg4anyv2w89kk74k5p0af0pj5`
-const setupTestingWallet = async (driver: WebDriver, extensionTitle: string) => {
-    await switchToWindow(driver, extensionTitle);
-
-    await driver.executeScript("return window.localStorage.setItem('wallets','demo');");
-    await driver.executeScript(
-        "return window.localStorage.setItem('wallets.demo.password','$rscrypt$0$DwgB$brb7JqhPEJbIxXOu/Jn3Aw==$8eWWdvAarl6IuOjViqAZuqhq05aD/YBjTAtioqtoC9U=$');",
-    );
-    await driver.executeScript(
-        "return window.localStorage.setItem('wallets.demo.xprv','4b83ff6937ce2650354d02d9c7f6d9b828824c1dbe4d0795b3b14d9c9042dbca$0c130f39ada0ec0e9e0e2a2af91815f7e77f8ed64481467f19e42bcdfeaf88af2d10df9e9143223b71e053f67fad830ec102c7e977bd646cd1dec3a2718c97dc7e98cd349c7a3c2147f78c9b8b6436f68b96e2bf73f11ca496483175ad5dfa577d1efb40827455b05e3c51f9745ed8d4726d49f4a54470073efea876815f25');",
-    );
-
-    return "el1qqf09atu8jsmd25eclm8t5relx9q3x80yw3yncesd3ez2rgzy2pxkmamlcgrwlfa523rd4vjmcg4anyv2w89kk74k5p0af0pj5";
-};
-
-const faucet = async (address: string) => {
-    let faucetUrl = `http://localhost:3030/api/faucet/${address}`;
-    let response = await fetch(faucetUrl, {
-        method: "POST",
-    });
-    expect(response.ok).toBeTruthy();
-};
-
 const unlockWallet = async (driver: WebDriver, extensionTitle: string) => {
     let debug = Debug("e2e-unlock-wallet");
 
@@ -124,4 +101,4 @@ async function takeScreenshot(driver, file) {
     await fsp.writeFile(file, image, "base64");
 }
 
-export { faucet, getElementById, setupBrowserWithExtension, setupTestingWallet, switchToWindow, unlockWallet };
+export { getElementById, setupBrowserWithExtension, switchToWindow, unlockWallet };

--- a/extension/src/components/CreateWallet.tsx
+++ b/extension/src/components/CreateWallet.tsx
@@ -77,6 +77,7 @@ function CreateWallet({ onUnlock }: CreateWalletProps) {
                         aria-label="Refresh"
                         icon={<RepeatIcon />}
                         isLoading={isGeneratingSeedWords}
+                        data-cy={"data-cy-create-wallet-generate-mnemonic"}
                         onClick={(_) => {
                             newSeedWords();
                         }}


### PR DESCRIPTION
This PR aims at having deterministic e2e tests. For that we remove as much randomness from the tests and move it into the e2e_test_setup.sh. 

- each test has its own file and own setup. With this approach we don't run into the danger of reusing the same state in different tests which can make problems
- each test uses its own wallet. that way a test does not spend utxos which are used elsewhere
- tests are run sequentially. By having a separate file for each test we can enforce that the tests are run sequentially. This is slower but removes randomness.
- No faucets in tests: by moving the funding of the test wallets into the e2e test setup we remove one more source of randomness.