### PR TITLE
Fix vanishing loans bug

### DIFF
--- a/extension/wallet/src/wallet/repay_loan.rs
+++ b/extension/wallet/src/wallet/repay_loan.rs
@@ -184,9 +184,10 @@ pub async fn repay_loan(
         Some(open_loans) => serde_json::from_str(&open_loans).map_err(Error::Deserialize)?,
         None => Vec::<LoanDetails>::new(),
     };
+
     let open_loans = open_loans
         .iter()
-        .take_while(|details| loan_txid != details.txid)
+        .filter(|details| loan_txid != details.txid)
         .collect::<Vec<_>>();
     storage
         .set_item(


### PR DESCRIPTION
Resolves #201

Use `filter` instead of `take_while`.

`Take_while` will stop as soon as the first closure returns false. That's why loans further down in the list vanished if you settled the first loan.

Signed-off-by: Philipp Hoenisch <philipp@hoenisch.at>