### PR TITLE
Lender creates timelock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitcoin"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +305,7 @@ dependencies = [
  "jsonrpc_client",
  "log",
  "mime_guess",
+ "proptest",
  "reqwest",
  "rust-embed",
  "rust_decimal",
@@ -1445,6 +1461,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits 0.2.14",
+ "quick-error 2.0.1",
+ "rand 0.8.3",
+ "rand_chacha 0.3.0",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,7 +1516,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -1639,6 +1687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1831,6 +1888,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -2530,6 +2599,15 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,8 +124,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "baru"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a23513ccaf1216e056a58cbf696e14c21c4b0236da951747c9ede655e7c502a"
+source = "git+https://github.com/da-kami/baru?branch=lender-decides-timelock#782ac49d81440f544dacc266d2720d48f3956655"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.9.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "baru"
 version = "0.2.0"
-source = "git+https://github.com/da-kami/baru?branch=lender-decides-timelock#782ac49d81440f544dacc266d2720d48f3956655"
+source = "git+https://github.com/da-kami/baru?branch=lender-decides-timelock#9bb512a0037b888659a8f66e6f1f5b682da1bd3b"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.9.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,17 +123,20 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "baru"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a925d16d7755d1f745724754b5812644fc6bcf9f2936de18c9710d707c2f87"
+checksum = "6a23513ccaf1216e056a58cbf696e14c21c4b0236da951747c9ede655e7c502a"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.9.6",
+ "conquer-once",
  "elements",
+ "elements-miniscript",
  "env_logger",
  "hex",
  "hmac 0.10.1",
  "log",
+ "rand 0.6.5",
  "rust_decimal",
  "secp256k1",
  "secp256k1-zkp",
@@ -156,10 +159,10 @@ checksum = "daeccaea73c9fc27e218e2a4402070707fb8354afd30fecd4a1c9a0bea8b79c4"
 dependencies = [
  "async-trait",
  "bdk-macros",
- "bitcoin",
+ "bitcoin 0.26.0",
  "js-sys",
  "log",
- "miniscript",
+ "miniscript 5.1.0",
  "rand 0.7.3",
  "serde 1.0.126",
  "serde_json 1.0.64",
@@ -184,6 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
 
 [[package]]
+name = "bech32"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9ff0bbfd639f15c74af777d81383cf53efb7c93613f6cab67c6c11e05bbf8b"
+
+[[package]]
 name = "bip32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,8 +214,20 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ec5f88a446d66e7474a3b8fa2e348320b574463fb78d799d90ba68f79f48e0e"
 dependencies = [
- "bech32",
+ "bech32 0.7.3",
  "bitcoin_hashes 0.9.6",
+ "secp256k1",
+ "serde 1.0.126",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a427b27dae305157520d86673f2393b3eb08d880609abfcffc6e3c3c820e764"
+dependencies = [
+ "bech32 0.8.1",
+ "bitcoin_hashes 0.10.0",
  "secp256k1",
  "serde 1.0.126",
 ]
@@ -222,6 +243,15 @@ name = "bitcoin_hashes"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e6d72ba9671cb0929b5620e1bc30cdf5e206ccb3dbaa8964d67f6efc1e16129"
+dependencies = [
+ "serde 1.0.126",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006cc91e1a1d99819bc5b8214be3555c1f0611b169f527a1fdc54ed1f2b745b0"
 dependencies = [
  "serde 1.0.126",
 ]
@@ -526,12 +556,12 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elements"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bc8e918eb82346053fc6dcac7281066778164bced4cfa40e4b2b2e4b219c8b"
+checksum = "aa776445bd0ef9b30eab2e7c09cacc3a545e0502c178fdca9c4c6d80f738d519"
 dependencies = [
- "bitcoin",
- "bitcoin_hashes 0.9.6",
+ "bitcoin 0.27.0",
+ "bitcoin_hashes 0.10.0",
  "secp256k1-zkp",
  "serde 1.0.126",
  "serde_json 0.9.10",
@@ -552,6 +582,18 @@ dependencies = [
  "thiserror",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "elements-miniscript"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc1fe1025a4d64d76bcc479685610a2d9c4903fdb1eb72c8bf4c2d1b3dbdc1a"
+dependencies = [
+ "bitcoin 0.27.0",
+ "elements",
+ "miniscript 6.0.0",
+ "serde 1.0.126",
 ]
 
 [[package]]
@@ -1145,7 +1187,16 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71f455be59a359d50370c4f587afbc5739c862e684c5afecae80ab93e7474b4e"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.26.0",
+]
+
+[[package]]
+name = "miniscript"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f88ac7d08e876153a4a81e851693db71f325b382baa77723f63210451e2414f"
+dependencies = [
+ "bitcoin 0.27.0",
 ]
 
 [[package]]
@@ -2499,7 +2550,6 @@ dependencies = [
  "aes-gcm-siv",
  "anyhow",
  "baru",
- "bdk",
  "bip32",
  "coin_selection",
  "conquer-once",

--- a/bobtimus/Cargo.toml
+++ b/bobtimus/Cargo.toml
@@ -21,6 +21,7 @@ http-api-problem = { version = "0.21", features = ["warp"] }
 jsonrpc_client = { version = "0.6", features = ["reqwest"] }
 log = "0.4"
 mime_guess = "2.0.3"
+proptest = "1"
 reqwest = "0.11"
 rust-embed = "5.7.0"
 rust_decimal = { version = "1.15", features = ["serde-float"] }

--- a/bobtimus/Cargo.toml
+++ b/bobtimus/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-baru = "0.2"
+baru = { git = "https://github.com/da-kami/baru", branch = "lender-decides-timelock" }
 bitcoin_hashes = "0.9.0"
 diesel = { version = "1.4", features = ["sqlite"] }
 diesel_migrations = "1.4"

--- a/bobtimus/Cargo.toml
+++ b/bobtimus/Cargo.toml
@@ -7,12 +7,12 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-baru = "0.1"
+baru = "0.2"
 bitcoin_hashes = "0.9.0"
 diesel = { version = "1.4", features = ["sqlite"] }
 diesel_migrations = "1.4"
 directories = "3.0"
-elements = { version = "0.17", features = ["serde-feature"] }
+elements = { version = "0.18", features = ["serde-feature"] }
 elements-harness = { git = "https://github.com/comit-network/elements-harness" }
 futures = { version = "0.3", default-features = false }
 hex = "0.4"

--- a/bobtimus/proptest-regressions/lib.txt
+++ b/bobtimus/proptest-regressions/lib.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9bb7f1b54a4968641948d278e51a05ed2930034b95de73641862e33bfcdcea4d # shrinks to term_in_days = 30868

--- a/bobtimus/src/database.rs
+++ b/bobtimus/src/database.rs
@@ -111,10 +111,10 @@ pub mod queries {
 
     pub fn get_publishable_liquidations_txs(
         conn: &SqliteConnection,
-        blockcount: u32,
+        secs_since_epoch: u64,
     ) -> Result<Vec<Transaction>> {
         let txs = liquidations::table
-            .filter(liquidations::locktime.le(blockcount as i64))
+            .filter(liquidations::locktime.le(secs_since_epoch as i64))
             .get_results::<Liquidation>(conn)?;
 
         let txs = txs

--- a/bobtimus/src/elements_rpc.rs
+++ b/bobtimus/src/elements_rpc.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use bitcoin_hashes::hex::FromHex;
 use elements::{
-    bitcoin::{Amount, PrivateKey},
+    bitcoin::Amount,
     confidential::{Asset, Nonce, Value},
     encode::serialize_hex,
     secp256k1_zkp::{SecretKey, Signature},
@@ -338,17 +338,15 @@ impl Client {
         Ok(sig)
     }
 
-    pub async fn dump_private_key(&self, address: &Address) -> Result<SecretKey> {
-        let privkey = self.dumpprivkey(address).await?;
-        let privkey = PrivateKey::from_wif(&privkey)?;
-
-        Ok(privkey.key)
-    }
-
     pub async fn get_blockcount(&self) -> Result<u32> {
         let blockcount = self.getblockcount().await?;
 
         Ok(blockcount)
+    }
+
+    pub async fn get_address_blinding_key(&self, address: &Address) -> Result<SecretKey> {
+        let key = self.dumpblindingkey(address).await?;
+        Ok(key)
     }
 }
 

--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -427,10 +427,14 @@ impl RateSubscription {
 }
 
 pub async fn liquidate_loans(elementsd: &Client, db: Sqlite) -> Result<()> {
-    let blockcount = elementsd.get_blockcount().await?;
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    let secs_since_epoch = now.as_secs();
+
     let liquidation_txs = db
         .do_in_transaction(|conn| {
-            let txs = queries::get_publishable_liquidations_txs(conn, blockcount)?;
+            let txs = queries::get_publishable_liquidations_txs(conn, secs_since_epoch)?;
             Ok(txs)
         })
         .await?;

--- a/coin_selection/Cargo.toml
+++ b/coin_selection/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 [dependencies]
 bdk = { version = "0.4", default-features = false }
-elements = "0.17"
+elements = "0.18"
 estimate_transaction_size = { path = "../estimate_transaction_size" }
 thiserror = "1"

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -73,7 +73,6 @@ browser.runtime.onMessage.addListener(async (msg: Message<any>, sender) => {
                             walletName,
                             msg.payload.collateral,
                             msg.payload.fee_rate,
-                            msg.payload.timeout,
                         ),
                     MessageKind.LoanResponse,
                 );

--- a/extension/src/components/OpenLoans.tsx
+++ b/extension/src/components/OpenLoans.tsx
@@ -20,7 +20,7 @@ import { LoanDetails } from "../models";
 import Btc from "./bitcoin.svg";
 import Usdt from "./tether.svg";
 
-const debug = Debug("openloans:error");
+const error = Debug("openloans:error");
 
 interface OpenLoansProps {
     openLoans: LoanDetails[] | undefined;
@@ -53,7 +53,7 @@ function OpenLoan({ loanDetails, onRepayed, index }: OpenLoanProps) {
             await repayLoan(loanDetails.txid);
             onRepayed();
         },
-        onReject: (e) => debug("Failed to repay loan %s: %s", loanDetails.txid, e),
+        onReject: (e) => error("Failed to repay loan %s: %s", loanDetails.txid, e),
     });
 
     const blockHeightHook = useAsync({

--- a/extension/src/components/OpenLoans.tsx
+++ b/extension/src/components/OpenLoans.tsx
@@ -20,7 +20,7 @@ import { LoanDetails } from "../models";
 import Btc from "./bitcoin.svg";
 import Usdt from "./tether.svg";
 
-const error = Debug("openloans:error");
+const debug = Debug("openloans:error");
 
 interface OpenLoansProps {
     openLoans: LoanDetails[] | undefined;
@@ -53,7 +53,7 @@ function OpenLoan({ loanDetails, onRepayed, index }: OpenLoanProps) {
             await repayLoan(loanDetails.txid);
             onRepayed();
         },
-        onReject: (e) => error("Failed to repay loan %s: %s", loanDetails.txid, e),
+        onReject: (e) => debug("Failed to repay loan %s: %s", loanDetails.txid, e),
     });
 
     const blockHeightHook = useAsync({

--- a/extension/src/wasmProxy.ts
+++ b/extension/src/wasmProxy.ts
@@ -59,12 +59,11 @@ export async function makeLoanRequestPayload(
     name: string,
     collateral: string,
     fee_rate: string,
-    timelock: string,
 ): Promise<CreateSwapPayload> {
     const { make_loan_request } = await import("./wallet");
 
     debug("makeLoanRequestPayload");
-    return make_loan_request(name, collateral, fee_rate, timelock);
+    return make_loan_request(name, collateral, fee_rate);
 }
 
 export async function signAndSendSwap(name: string, hex: string): Promise<Txid> {

--- a/extension/wallet/Cargo.toml
+++ b/extension/wallet/Cargo.toml
@@ -13,13 +13,12 @@ default = ["console_error_panic_hook"]
 [dependencies]
 aes-gcm-siv = { version = "0.9", features = ["std"] }
 anyhow = "1"
-baru = "0.1"
-bdk = { version = "0.4", default-features = false }
+baru = "0.2"
 bip32 = { version = "0.2", features = ["secp256k1-ffi", "bip39"], default-features = false }
 coin_selection = { path = "../../coin_selection" }
 conquer-once = "0.3"
 console_error_panic_hook = { version = "0.1.6", optional = true }
-elements = { version = "0.17", features = ["serde-feature"] }
+elements = { version = "0.18", features = ["serde-feature"] }
 estimate_transaction_size = { path = "../../estimate_transaction_size" }
 futures = "0.3"
 getrandom = { version = "0.2", features = ["wasm-bindgen", "js"] }
@@ -48,7 +47,7 @@ wasm-bindgen-test = "0.3.13"
 [build-dependencies]
 anyhow = "1"
 conquer-once = "0.3"
-elements = { version = "0.17" }
+elements = { version = "0.18" }
 
 # By default wasm-opt is true which makes the build fail.
 [package.metadata.wasm-pack.profile.release]

--- a/extension/wallet/Cargo.toml
+++ b/extension/wallet/Cargo.toml
@@ -13,7 +13,7 @@ default = ["console_error_panic_hook"]
 [dependencies]
 aes-gcm-siv = { version = "0.9", features = ["std"] }
 anyhow = "1"
-baru = "0.2"
+baru = { git = "https://github.com/da-kami/baru", branch = "lender-decides-timelock" }
 bip32 = { version = "0.2", features = ["secp256k1-ffi", "bip39"], default-features = false }
 coin_selection = { path = "../../coin_selection" }
 conquer-once = "0.3"

--- a/extension/wallet/src/esplora.rs
+++ b/extension/wallet/src/esplora.rs
@@ -39,10 +39,16 @@ pub async fn fetch_utxos(address: &Address) -> Result<Vec<Utxo>> {
         ));
     }
 
-    response
+    let mut utxos = response
         .json::<Vec<Utxo>>()
         .await
-        .context("failed to deserialize response")
+        .context("failed to deserialize response")?;
+
+    // Sort UTXOs to have more deterministic output in case something goes wrong.
+    // Note that the order of these UTXOs does not have to be strictly assured.
+    utxos.sort_by(|l, r| l.txid.cmp(&r.txid).then(l.vout.cmp(&r.vout)));
+
+    Ok(utxos)
 }
 
 /// Fetch transaction history for the specified address.

--- a/extension/wallet/src/lib.rs
+++ b/extension/wallet/src/lib.rs
@@ -235,19 +235,16 @@ pub async fn make_loan_request(
     wallet_name: String,
     collateral: String,
     fee_rate: String,
-    timeout: String,
 ) -> Result<JsValue, JsValue> {
     // TODO: Change the UI to handle SATs not BTC
     let collateral_in_btc = map_err_from_anyhow!(parse_to_bitcoin_amount(collateral))?;
     let fee_rate_in_sat = Amount::from_sat(map_err_from_anyhow!(u64::from_str(fee_rate.as_str()))?);
-    let timeout = map_err_from_anyhow!(u32::from_str(timeout.as_str()))?;
     let loan_request = map_err_from_anyhow!(
         wallet::make_loan_request(
             wallet_name,
             &LOADED_WALLET,
             collateral_in_btc,
             fee_rate_in_sat,
-            timeout
         )
         .await
     )?;

--- a/extension/wallet/src/lib.rs
+++ b/extension/wallet/src/lib.rs
@@ -240,7 +240,7 @@ pub async fn make_loan_request(
     // TODO: Change the UI to handle SATs not BTC
     let collateral_in_btc = map_err_from_anyhow!(parse_to_bitcoin_amount(collateral))?;
     let fee_rate_in_sat = Amount::from_sat(map_err_from_anyhow!(u64::from_str(fee_rate.as_str()))?);
-    let timeout = map_err_from_anyhow!(u64::from_str(timeout.as_str()))?;
+    let timeout = map_err_from_anyhow!(u32::from_str(timeout.as_str()))?;
     let loan_request = map_err_from_anyhow!(
         wallet::make_loan_request(
             wallet_name,

--- a/extension/wallet/src/wallet.rs
+++ b/extension/wallet/src/wallet.rs
@@ -310,8 +310,8 @@ impl fmt::Display for ListOfWallets {
 pub struct CreateSwapPayload {
     pub alice_inputs: Vec<SwapUtxo>,
     pub address: Address,
-    #[serde(with = "bdk::bitcoin::util::amount::serde::as_sat")]
-    pub amount: bdk::bitcoin::Amount,
+    #[serde(with = "elements::bitcoin::util::amount::serde::as_sat")]
+    pub amount: elements::bitcoin::Amount,
 }
 
 #[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
@@ -426,7 +426,7 @@ pub struct LoanDetails {
     pub principal: TradeSide,
     pub principal_repayment: Decimal,
     // TODO: Express as target date or number of days instead?
-    pub term: u64,
+    pub term: u32,
     pub txid: Txid,
 }
 
@@ -439,7 +439,7 @@ impl LoanDetails {
         principal_asset: AssetId,
         principal_amount: Amount,
         principal_balance: Decimal,
-        timelock: u64,
+        timelock: u32,
         txid: Txid,
     ) -> Result<Self> {
         let collateral = TradeSide::new_sell(

--- a/extension/wallet/src/wallet/make_create_swap_payload.rs
+++ b/extension/wallet/src/wallet/make_create_swap_payload.rs
@@ -2,9 +2,8 @@ use crate::{
     wallet::{current, get_txouts, CreateSwapPayload, SwapUtxo, Wallet},
     BTC_ASSET_ID, USDT_ASSET_ID,
 };
-use bdk::bitcoin::Amount;
 use coin_selection::{self, coin_select};
-use elements::{secp256k1_zkp::SECP256K1, AssetId, OutPoint};
+use elements::{bitcoin::Amount, secp256k1_zkp::SECP256K1, AssetId, OutPoint};
 use estimate_transaction_size::avg_vbytes;
 use futures::lock::Mutex;
 use wasm_bindgen::UnwrapThrowExt;

--- a/extension/wallet/src/wallet/make_loan_request.rs
+++ b/extension/wallet/src/wallet/make_loan_request.rs
@@ -19,7 +19,7 @@ pub async fn make_loan_request(
     current_wallet: &Mutex<Option<Wallet>>,
     collateral_amount: Amount,
     fee_rate: Amount,
-    timelock: u64,
+    timelock: u32,
 ) -> Result<LoanRequest, Error> {
     let btc_asset_id = {
         let guard = BTC_ASSET_ID.lock().expect_throw("can get lock");

--- a/extension/wallet/src/wallet/make_loan_request.rs
+++ b/extension/wallet/src/wallet/make_loan_request.rs
@@ -19,7 +19,6 @@ pub async fn make_loan_request(
     current_wallet: &Mutex<Option<Wallet>>,
     collateral_amount: Amount,
     fee_rate: Amount,
-    timelock: u32,
 ) -> Result<LoanRequest, Error> {
     let btc_asset_id = {
         let guard = BTC_ASSET_ID.lock().expect_throw("can get lock");
@@ -113,7 +112,6 @@ pub async fn make_loan_request(
         blinding_key,
         collateral_amount,
         fee_rate,
-        timelock,
         btc_asset_id,
         usdt_asset_id,
     )

--- a/waves/src/App.test.tsx
+++ b/waves/src/App.test.tsx
@@ -1,9 +1,5 @@
-import { act, render, screen } from "@testing-library/react";
 import React from "react";
-import { Listener, Source, SSEProvider } from "react-hooks-sse";
-import { BrowserRouter } from "react-router-dom";
-import App, { Asset, reducer, State } from "./App";
-import { Interest, Rate } from "./Bobtimus";
+import { Asset, reducer, State } from "./App";
 import calculateBetaAmount from "./calculateBetaAmount";
 
 const defaultLoanOffer = {
@@ -16,8 +12,9 @@ const defaultLoanOffer = {
     max_principal: 10000,
     max_ltv: 0.8,
     interest: [{
-        timelock: 43200,
+        term: 30,
         interest_rate: 0.15,
+        collateralization: 1.5,
     }],
 };
 

--- a/waves/src/App.tsx
+++ b/waves/src/App.tsx
@@ -224,7 +224,7 @@ export function reducer(state: State = initialState, action: Action) {
             // TODO: We currently always overwrite upon a new loan offer
             //  This will have to be adapted once we refresh loan offers.
             const principalAmount = action.value.min_principal.toString();
-            const loanTermInDays = action.value.interest[0].timelock / 60 / 24;
+            const loanTermInDays = action.value.interest[0].term;
 
             return {
                 ...state,

--- a/waves/src/Borrow.tsx
+++ b/waves/src/Borrow.tsx
@@ -72,17 +72,13 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
 
             try {
                 const feeRate = state.loanOffer!.fee_sats_per_vbyte;
-                // Liquid has 1 minute blocktime
-                const loanTermInBlocks = state.loanTermInDays * 24 * 60;
 
-                debug("loan term in blocks: " + loanTermInBlocks);
-
-                let loanRequest = await wavesProvider.makeLoanRequestPayload(
+                let loanRequestWalletParams = await wavesProvider.makeLoanRequestPayload(
                     collateralAmount.toString(),
                     feeRate.toString(),
-                    loanTermInBlocks.toString(),
                 );
-                let loanResponse = await postLoanRequest(loanRequest);
+
+                let loanResponse = await postLoanRequest(loanRequestWalletParams, state.loanTermInDays);
                 debug(JSON.stringify(loanResponse));
 
                 let loanTransaction = await wavesProvider.signLoan(loanResponse);

--- a/waves/src/waves-provider/index.d.ts
+++ b/waves/src/waves-provider/index.d.ts
@@ -18,7 +18,6 @@ export default class WavesProvider {
     public async makeLoanRequestPayload(
         collateral: string,
         fee_rate: string,
-        timeout: string,
     ): Promise<LoanRequestPayload>;
 
     public async signAndSendSwap(tx_hex: string): Promise<Txid>;

--- a/waves/src/waves-provider/wavesProvider.ts
+++ b/waves/src/waves-provider/wavesProvider.ts
@@ -35,7 +35,6 @@ export interface LoanRequestPayload {
     collateral_inputs: { txin: OutPoint; original_txout: any; blinding_key: string }[];
     fee_sats_per_vbyte: number;
     borrower_pk: string;
-    timelock: number;
     borrower_address: string;
 }
 


### PR DESCRIPTION
Instead of calculating the absolute timelock for the loan offer (which would mean that it already "declines" while the user is still chosing a loan) we use relative loan term in days and the absolute timelock is calculated by the lender upon loan request. The borrower has to check that the timelock is as expected when signing the loan (has to check anyway).

includes upgrading to baru `0.2` :)

fixes #220 