### PR TITLE
Lock selected utxos to not double select them.

### DIFF
--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -130,7 +130,7 @@ where
         input_amount: Amount,
     ) -> Result<Vec<Input>> {
         let bob_inputs = elements_client
-            .select_inputs_for(asset_id, input_amount, false)
+            .select_inputs_for(asset_id, input_amount, true)
             .await
             .context("failed to select inputs for swap")?;
 


### PR DESCRIPTION
This fixes an issue were bobtimus tries to double spend himself. If we do not lock the selected utxos bobtimus might just reselect them. This can cause a race condition if two competing transactions are trying to spend the same utxo.

Note: this can cause side effects were bobtimus runs out of money. If this happens, we need to manually mine a block.

resolves #200 