### PR TITLE
Upgrade Botimus to handle loan calc and validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,15 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,24 +114,19 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "baru"
-version = "0.2.0"
-source = "git+https://github.com/da-kami/baru?branch=lender-decides-timelock#9bb512a0037b888659a8f66e6f1f5b682da1bd3b"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1eb13099fe659a09223f8a1093888217486410e75c4943f61a1216d49f4219"
 dependencies = [
  "anyhow",
- "bitcoin_hashes 0.9.6",
  "conquer-once",
  "elements",
  "elements-miniscript",
- "env_logger",
  "hex",
- "hmac 0.10.1",
  "log",
  "rand 0.6.5",
  "rust_decimal",
- "secp256k1",
- "secp256k1-zkp",
  "serde 1.0.126",
- "sha2",
  "thiserror",
 ]
 
@@ -317,6 +303,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "testcontainers",
+ "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -619,19 +606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -968,12 +942,6 @@ name = "httpdate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1734,8 +1702,6 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -2244,15 +2210,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/bobtimus/Cargo.toml
+++ b/bobtimus/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-baru = { git = "https://github.com/da-kami/baru", branch = "lender-decides-timelock" }
+baru = "0.3"
 bitcoin_hashes = "0.9.0"
 diesel = { version = "1.4", features = ["sqlite"] }
 diesel_migrations = "1.4"
@@ -31,6 +31,7 @@ serde_json = "1"
 sha2 = "0.9"
 structopt = "0.3"
 tempfile = "3.2"
+thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-tungstenite = { version = "0.13", features = ["tls"] }
 tracing = "0.1"

--- a/bobtimus/proptest-regressions/lib.txt
+++ b/bobtimus/proptest-regressions/lib.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 9bb7f1b54a4968641948d278e51a05ed2930034b95de73641862e33bfcdcea4d # shrinks to term_in_days = 30868
+cc 1ea9687935221688e83172c1a589fbb8beb2dbfeb527c320dd9810a402281a8a # shrinks to principal_amount = 15775565394041882682, interest_percentage = 0.16932377

--- a/bobtimus/src/amounts.rs
+++ b/bobtimus/src/amounts.rs
@@ -5,7 +5,7 @@ use rust_decimal::{
     Decimal, RoundingStrategy,
 };
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt::Debug};
+use std::{convert::TryFrom, fmt, fmt::Debug};
 
 /// Prices at which 1 L-BTC will be traded, in L-USDt.
 ///
@@ -62,7 +62,7 @@ impl Rate {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Serialize, Default)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Serialize, Deserialize, Default)]
 pub struct LiquidUsdt(#[serde(with = "::elements::bitcoin::util::amount::serde::as_sat")] Amount);
 
 impl LiquidUsdt {
@@ -125,8 +125,17 @@ impl TryFrom<f64> for LiquidUsdt {
     }
 }
 
+impl fmt::Display for LiquidUsdt {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_value_in(f, Denomination::Bitcoin)?;
+        write!(f, " L-USDT")
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct LiquidBtc(#[serde(with = "::elements::bitcoin::util::amount::serde::as_sat")] Amount);
+pub struct LiquidBtc(
+    #[serde(with = "::elements::bitcoin::util::amount::serde::as_sat")] pub Amount,
+);
 
 impl From<Amount> for LiquidBtc {
     fn from(amount: Amount) -> Self {

--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -43,9 +43,14 @@ pub mod loan;
 pub mod problem;
 pub mod schema;
 
-use crate::loan::{Interest, LoanOffer, LoanRequest};
+use crate::loan::{
+    calculate_interest_rate, calculate_liquidation_price, calculate_ltv,
+    calculate_repayment_amount, calculate_request_price, validate_loan_is_acceptable,
+    Collateralization, LoanOffer, LoanRequest, Term,
+};
 pub use amounts::*;
 use elements::bitcoin::PublicKey;
+use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::{
     convert::TryFrom,
@@ -270,32 +275,92 @@ where
     /// We return the range of possible loan terms to the borrower.
     /// The borrower can then request a loan using parameters that are within our terms.
     pub async fn handle_loan_offer_request(&mut self) -> Result<LoanOffer> {
-        Ok(LoanOffer {
+        Ok(self.current_loan_offer())
+    }
+
+    fn current_loan_offer(&mut self) -> LoanOffer {
+        LoanOffer {
             rate: self.rate_service.latest_rate(),
             // TODO: Dynamic fee estimation
             fee_sats_per_vbyte: Amount::from_sat(1),
-            // TODO: Send sats over the wire and refactor waves reducer to use amount classes
             min_principal: LiquidUsdt::from_str_in_dollar("100")
                 .expect("static value to be convertible"),
             max_principal: LiquidUsdt::from_str_in_dollar("10000")
                 .expect("static value to be convertible"),
+            // TODO: Maximum LTV to be decided by a model
             max_ltv: dec!(0.8),
-            // TODO: Dynamic interest based on current market values
-            interest: vec![Interest {
-                term: 30,
-                interest_rate: dec!(0.15),
-                collateralization: dec!(1.5),
-            }],
-        })
+            // TODO: Interest to be decided by a model
+            base_interest_rate: dec!(0.05),
+            // TODO: Potentially fine-tune the model with these values
+            terms: vec![
+                Term {
+                    days: 30,
+                    interest_mod: Decimal::ZERO,
+                },
+                Term {
+                    days: 60,
+                    interest_mod: Decimal::ZERO,
+                },
+                Term {
+                    days: 120,
+                    interest_mod: Decimal::ZERO,
+                },
+            ],
+            collateralizations: vec![
+                Collateralization {
+                    collateralization: dec!(1.5),
+                    interest_mod: Decimal::ZERO,
+                },
+                Collateralization {
+                    collateralization: dec!(2.0),
+                    interest_mod: Decimal::ZERO,
+                },
+            ],
+        }
     }
 
     /// Handle the borrower's loan request in which she puts up L-BTC as
     /// collateral and we lend L-USDt to her which she will have to
     /// repay in the future.
-    pub async fn handle_loan_request(&mut self, payload: LoanRequest) -> Result<LoanResponse> {
-        // TODO: Ensure that the loan requested is within what we "currently" accept.
-        //  Currently there is no ID for incoming loan requests, that would associate them with an offer,
-        //  so we just have to ensure that the loan is still "acceptable" in the current state of Bobtimus.
+    pub async fn handle_loan_request(&mut self, loan_request: LoanRequest) -> Result<LoanResponse> {
+        let loan_offer = self.current_loan_offer();
+
+        let interest_rate = calculate_interest_rate(
+            loan_request.term,
+            loan_request.collateralization,
+            &loan_offer.terms,
+            &loan_offer.collateralizations,
+            loan_offer.base_interest_rate,
+        )?;
+        let repayment_amount =
+            calculate_repayment_amount(loan_request.principal_amount, interest_rate)?;
+
+        let request_price = calculate_request_price(
+            repayment_amount,
+            loan_request.collateral_amount,
+            loan_request.collateralization,
+        )?;
+
+        let current_price = self.rate_service.latest_rate();
+        let request_ltv = calculate_ltv(
+            repayment_amount,
+            loan_request.collateral_amount,
+            current_price.bid,
+        )?;
+
+        // TODO: Make configurable
+        let price_fluctuation_interval = (dec!(0.99), dec!(1.01));
+
+        validate_loan_is_acceptable(
+            request_price,
+            current_price.bid,
+            price_fluctuation_interval,
+            loan_request.principal_amount,
+            loan_offer.min_principal,
+            loan_offer.max_principal,
+            request_ltv,
+            loan_offer.max_ltv,
+        )??;
 
         let oracle_secret_key = elements::secp256k1_zkp::key::ONE_KEY;
         let oralce_priv_key = elements::bitcoin::PrivateKey::new(
@@ -304,7 +369,7 @@ where
         );
         let oracle_pk = PublicKey::from_private_key(&self.secp, &oralce_priv_key);
 
-        let timelock = days_to_unix_timestamp_timelock(payload.term, SystemTime::now())?;
+        let timelock = days_to_unix_timestamp_timelock(loan_request.term, SystemTime::now())?;
 
         let lender_address = self
             .elementsd
@@ -327,22 +392,34 @@ where
         )
         .unwrap();
 
+        let elementsd_client = self.elementsd.clone();
+        let principal_inputs = Self::find_inputs(
+            &elementsd_client,
+            self.usdt_asset_id,
+            loan_request.principal_amount.into(),
+        )
+        .await?;
+
+        let liquidation_price =
+            calculate_liquidation_price(repayment_amount, loan_request.collateral_amount)?;
+
         let lender1 = lender0
-            .interpret(
+            .build_loan_transaction(
                 &mut self.rng,
                 &SECP256K1,
-                {
-                    let elementsd_client = self.elementsd.clone();
-                    |amount, asset| async move {
-                        Self::find_inputs(&elementsd_client, asset, amount).await
-                    }
-                },
-                payload.into(),
-                self.rate_service.latest_rate().bid.as_satodollar(),
+                loan_offer.fee_sats_per_vbyte,
+                (
+                    loan_request.collateral_amount.into(),
+                    loan_request.collateral_inputs,
+                ),
+                (loan_request.principal_amount.into(), principal_inputs),
+                repayment_amount.into(),
+                liquidation_price.as_satodollar(),
+                (loan_request.borrower_pk, loan_request.borrower_address),
                 timelock,
             )
             .await
-            .unwrap();
+            .context("Failed to build loan transaction")?;
 
         let loan_response = lender1.loan_response();
 

--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -324,7 +324,9 @@ where
         let loan_offer = self.current_loan_offer();
         // TODO: Make configurable
         let price_fluctuation_interval = (dec!(0.99), dec!(1.01));
-        let current_price = self.rate_service.latest_rate();
+
+        // The bid price is used so the lender is covered under the assumption of selling the asset
+        let current_price = self.rate_service.latest_rate().bid;
 
         let ValidatedLoan {
             repayment_amount,
@@ -333,7 +335,7 @@ where
             &loan_request,
             &loan_offer,
             price_fluctuation_interval,
-            current_price.ask,
+            current_price,
         )?;
 
         let oracle_secret_key = elements::secp256k1_zkp::key::ONE_KEY;

--- a/bobtimus/src/loan.rs
+++ b/bobtimus/src/loan.rs
@@ -1,10 +1,11 @@
-use crate::{LiquidUsdt, Rate};
+use crate::{LiquidBtc, LiquidUsdt, Rate};
+use anyhow::{Context, Result};
 use baru::input::Input;
 use elements::{
     bitcoin::{Amount, PublicKey},
     Address,
 };
-use rust_decimal::Decimal;
+use rust_decimal::{prelude::ToPrimitive, Decimal};
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct LoanOffer {
@@ -44,42 +45,520 @@ pub struct LoanOffer {
     /// The max_ltv protects the lender from Bitcoin falling too much.
     pub max_ltv: Decimal,
 
-    pub interest: Vec<Interest>,
+    /// Base interest in percent (to be applied to the principal amount)
+    pub base_interest_rate: Decimal,
+
+    /// Interest in relation to terms
+    pub terms: Vec<Term>,
+
+    /// Interest rates in relation to collteralization
+    pub collateralizations: Vec<Collateralization>,
 }
 
-#[derive(Debug, Clone, serde::Serialize)]
-pub struct Interest {
-    /// Loan term in days
-    pub term: u32,
-    /// Collateralization in percent
-    ///
-    /// Rational: If a borrower over-collateralizes with e.g. 150% -> better rate than at 140%
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Term {
+    pub days: u32,
+    /// Interest to be added on top of the base interest rate for this term
+    pub interest_mod: Decimal,
+}
+
+/// Allows to specify a better rate for users that
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Collateralization {
     pub collateralization: Decimal,
-    /// Interest rate in percent
-    pub interest_rate: Decimal,
+    /// Interest to be added on top of the base interest rate for this term.
+    pub interest_mod: Decimal,
 }
 
+// TODO: Make sure that removing sat_per_vbyte is OK here
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct LoanRequest {
-    #[serde(with = "::elements::bitcoin::util::amount::serde::as_sat")]
-    pub collateral_amount: Amount,
-    collateral_inputs: Vec<Input>,
-    #[serde(with = "::elements::bitcoin::util::amount::serde::as_sat")]
-    fee_sats_per_vbyte: Amount,
-    borrower_pk: PublicKey,
+    pub principal_amount: LiquidUsdt,
+    pub collateral_amount: LiquidBtc,
+    pub collateral_inputs: Vec<Input>,
+    pub collateralization: Decimal,
+    pub borrower_pk: PublicKey,
     /// Loan term in days
     pub term: u32,
-    borrower_address: Address,
+    pub borrower_address: Address,
 }
 
-impl From<LoanRequest> for baru::loan::LoanRequest {
-    fn from(loan_request: LoanRequest) -> Self {
-        baru::loan::LoanRequest::new(
-            loan_request.collateral_amount,
-            loan_request.collateral_inputs,
-            loan_request.fee_sats_per_vbyte,
-            loan_request.borrower_pk,
-            loan_request.borrower_address,
+pub fn calculate_interest_rate(
+    borrower_term: u32,
+    borrower_collateralization: Decimal,
+    term_thresholds: &[Term],
+    collateralization_thresholds: &[Collateralization],
+    base_interest_rate: Decimal,
+) -> Result<Decimal> {
+    let mut term_interest_mod = Decimal::ZERO;
+    for term in term_thresholds {
+        if borrower_term >= term.days {
+            term_interest_mod = term.interest_mod;
+            continue;
+        }
+        break;
+    }
+
+    let mut collateralization_interest_mod = Decimal::ZERO;
+    for collateralization in collateralization_thresholds {
+        if borrower_collateralization >= collateralization.collateralization {
+            collateralization_interest_mod = collateralization.interest_mod;
+            continue;
+        }
+        break;
+    }
+
+    let interest_rate = base_interest_rate
+        .checked_add(term_interest_mod)
+        .context("Overflow due to addition")?
+        .checked_add(collateralization_interest_mod)
+        .context("Overflow due to addition")?;
+
+    Ok(interest_rate)
+}
+
+pub fn calculate_repayment_amount(
+    principal_amount: LiquidUsdt,
+    interest_percentage: Decimal,
+) -> Result<LiquidUsdt> {
+    let principal_amount = Decimal::from(principal_amount.as_satodollar());
+
+    let repayment_amount = principal_amount
+        .checked_add(
+            principal_amount
+                .checked_mul(interest_percentage)
+                .context("multiplication overflow")?,
+        )
+        .context("addition overflow")?;
+    let repayment_amount = LiquidUsdt::from_satodollar(
+        repayment_amount
+            .to_u64()
+            .context("decimal cannot be represented as u64")?,
+    );
+
+    Ok(repayment_amount)
+}
+
+pub fn calculate_liquidation_price(
+    repayment_amount: LiquidUsdt,
+    collateral_amount: LiquidBtc,
+) -> Result<LiquidUsdt> {
+    let repayment_amount = Decimal::from(repayment_amount.as_satodollar());
+    let one_btc_as_sat = Decimal::from(Amount::ONE_BTC.as_sat());
+    let collateral_as_btc = Decimal::from(collateral_amount.0.as_sat())
+        .checked_div(one_btc_as_sat)
+        .context("division error")?;
+
+    let liquidation_price = repayment_amount
+        .checked_div(collateral_as_btc)
+        .context("division error")?;
+    let liquidation_price = LiquidUsdt::from_satodollar(
+        liquidation_price
+            .to_u64()
+            .context("decimal cannot be represented as u64")?,
+    );
+
+    Ok(liquidation_price)
+}
+
+pub fn calculate_request_price(
+    repayment_amount: LiquidUsdt,
+    collateral_amount: LiquidBtc,
+    collateralization: Decimal,
+) -> Result<LiquidUsdt> {
+    let repayment_amount = Decimal::from(repayment_amount.as_satodollar());
+
+    let one_btc_as_sat = Decimal::from(Amount::ONE_BTC.as_sat());
+    let collateral_as_btc = Decimal::from(collateral_amount.0.as_sat())
+        .checked_div(one_btc_as_sat)
+        .context("division error")?;
+
+    let price = repayment_amount
+        .checked_div(
+            collateral_as_btc
+                .checked_div(collateralization)
+                .context("division error")?,
+        )
+        .context("division error")?;
+    let price = LiquidUsdt::from_satodollar(
+        price
+            .to_u64()
+            .context("decimal cannot be represented as u64")?,
+    );
+
+    Ok(price)
+}
+
+pub fn calculate_ltv(
+    repayment_amount: LiquidUsdt,
+    collateral_amount: LiquidBtc,
+    current_bid_price: LiquidUsdt,
+) -> Result<Decimal> {
+    let repayment_amount = Decimal::from(repayment_amount.as_satodollar());
+    let price = Decimal::from(current_bid_price.as_satodollar());
+
+    let one_btc = Decimal::from(Amount::ONE_BTC.as_sat());
+    let collateral_in_btc = Decimal::from(collateral_amount.0.as_sat())
+        .checked_div(one_btc)
+        .context("division error")?;
+
+    let ltv = repayment_amount
+        .checked_div(
+            collateral_in_btc
+                .checked_mul(price)
+                .context("multiplication error")?,
+        )
+        .context("division error")?;
+
+    Ok(ltv)
+}
+
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum LoanValidationError {
+    #[error(
+        "The given price {request_price} is not acceptable with current price {current_price}"
+    )]
+    PriceNotAcceptable {
+        request_price: LiquidUsdt,
+        current_price: LiquidUsdt,
+    },
+
+    #[error("The given principal amount {request_principal} is below the configured minimum {min_principal}")]
+    PrincipalBelowMin {
+        request_principal: LiquidUsdt,
+        min_principal: LiquidUsdt,
+    },
+
+    #[error("The given principal amount {request_principal} is above the configured maximum {max_principal}")]
+    PrincipalAboveMax {
+        request_principal: LiquidUsdt,
+        max_principal: LiquidUsdt,
+    },
+
+    #[error("The LTV value {request_ltv} is above the configured maximum {max_ltv}")]
+    LtvAboveMax {
+        request_ltv: Decimal,
+        max_ltv: Decimal,
+    },
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn validate_loan_is_acceptable(
+    request_price: LiquidUsdt,
+    current_price: LiquidUsdt,
+    price_fluctuation_interval: (Decimal, Decimal),
+    request_principal: LiquidUsdt,
+    min_principal: LiquidUsdt,
+    max_principal: LiquidUsdt,
+    request_ltv: Decimal,
+    max_ltv: Decimal,
+) -> Result<Result<(), LoanValidationError>> {
+    let request_price_dec = Decimal::from(request_price.as_satodollar());
+    let current_price_dec = Decimal::from(current_price.as_satodollar());
+
+    // TODO: Evaluate if we want to use an upper and a lower bound.
+    //  We could just restrict by upper bound, because that is what makes it more expensive for the lender
+    //  i.e. if price was 1000 and is 100 now we must ensure to accept only if the current price it not higher than 100 + x%
+    let (lower, upper) = price_fluctuation_interval;
+    let lower_bound = current_price_dec
+        .checked_mul(lower)
+        .context("multiplication error")?;
+    let upper_bound = current_price_dec
+        .checked_mul(upper)
+        .context("multiplication error")?;
+
+    if request_price_dec < lower_bound || request_price_dec > upper_bound {
+        return Ok(Err(LoanValidationError::PriceNotAcceptable {
+            request_price,
+            current_price,
+        }));
+    }
+
+    if request_principal < min_principal {
+        return Ok(Err(LoanValidationError::PrincipalBelowMin {
+            request_principal,
+            min_principal,
+        }));
+    }
+
+    if request_principal > max_principal {
+        return Ok(Err(LoanValidationError::PrincipalAboveMax {
+            request_principal,
+            max_principal,
+        }));
+    }
+
+    if request_ltv > max_ltv {
+        return Ok(Err(LoanValidationError::LtvAboveMax {
+            request_ltv,
+            max_ltv,
+        }));
+    }
+
+    Ok(Ok(()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::proptest;
+    use rust_decimal::prelude::FromPrimitive;
+    use rust_decimal_macros::dec;
+
+    #[test]
+    fn test_calculate_interest_rate() {
+        let term_thresholds = vec![Term {
+            days: 30,
+            interest_mod: dec!(0.001),
+        }];
+        let collateralization_thresholds = vec![Collateralization {
+            collateralization: dec!(1.5),
+            interest_mod: dec!(-0.002),
+        }];
+        let base_interest_rate = dec!(0.05);
+
+        let borrower_term = 30;
+        let borrower_collateralization = dec!(1.5);
+        let interest_rate = calculate_interest_rate(
+            borrower_term,
+            borrower_collateralization,
+            &term_thresholds,
+            &collateralization_thresholds,
+            base_interest_rate,
+        )
+        .unwrap();
+        assert_eq!(interest_rate, dec!(0.049));
+
+        let borrower_term = 29;
+        let borrower_collateralization = dec!(1.4);
+        let interest_rate = calculate_interest_rate(
+            borrower_term,
+            borrower_collateralization,
+            &term_thresholds,
+            &collateralization_thresholds,
+            base_interest_rate,
+        )
+        .unwrap();
+        assert_eq!(interest_rate, dec!(0.05));
+
+        let borrower_term = 30;
+        let borrower_collateralization = dec!(1.4);
+        let interest_rate = calculate_interest_rate(
+            borrower_term,
+            borrower_collateralization,
+            &term_thresholds,
+            &collateralization_thresholds,
+            base_interest_rate,
+        )
+        .unwrap();
+        assert_eq!(interest_rate, dec!(0.051));
+
+        let borrower_term = 29;
+        let borrower_collateralization = dec!(1.5);
+        let interest_rate = calculate_interest_rate(
+            borrower_term,
+            borrower_collateralization,
+            &term_thresholds,
+            &collateralization_thresholds,
+            base_interest_rate,
+        )
+        .unwrap();
+        assert_eq!(interest_rate, dec!(0.048));
+    }
+
+    #[test]
+    fn test_calculate_repayment_amount() {
+        let principal_amount = LiquidUsdt::from_satodollar(10000);
+        let interest_percentage = dec!(0.05);
+
+        let repayment_amount =
+            calculate_repayment_amount(principal_amount, interest_percentage).unwrap();
+        assert_eq!(repayment_amount, LiquidUsdt::from_satodollar(10500));
+    }
+
+    proptest! {
+        #[test]
+        fn test_calculate_repayment_amount_no_panic(
+            // we eventually hit decimal limits, but the amounts are so high that is should not matter
+            principal_amount in 1u64..15_000_000_000_000_000_000, // satdollar ^= 150 billion usd
+            interest_percentage in 0.001f32..0.2,
+        ) {
+            let principal_amount = LiquidUsdt::from_satodollar(principal_amount);
+            let interest_percentage = Decimal::from_f32(interest_percentage).unwrap();
+
+            let _ = calculate_repayment_amount(principal_amount, interest_percentage).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_calculate_liquidation_price() {
+        let repayment_amount = LiquidUsdt::from_str_in_dollar("10500").unwrap();
+        let collateral = LiquidBtc::from(Amount::from_btc(0.35).unwrap());
+
+        let liquidation_price = calculate_liquidation_price(repayment_amount, collateral).unwrap();
+
+        assert_eq!(
+            liquidation_price,
+            LiquidUsdt::from_str_in_dollar("30000").unwrap()
+        )
+    }
+
+    proptest! {
+        #[test]
+        fn test_calculate_liquidation_price_no_panic(
+            repayment_amount in 1u64..,
+            collateral in 1u64..,
+        ) {
+            let repayment_amount = LiquidUsdt::from_satodollar(repayment_amount);
+            let collateral = LiquidBtc::from(Amount::from_sat(collateral));
+
+            let _ = calculate_liquidation_price(repayment_amount, collateral).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_calculate_price() {
+        let repayment_amount = LiquidUsdt::from_str_in_dollar("10500").unwrap();
+        let collateral = LiquidBtc::from(Amount::from_btc(0.39375).unwrap());
+        let collateralization = dec!(1.5);
+
+        let price =
+            calculate_request_price(repayment_amount, collateral, collateralization).unwrap();
+
+        assert_eq!(price, LiquidUsdt::from_str_in_dollar("40000").unwrap());
+    }
+
+    #[test]
+    fn test_calculate_ltv() {
+        let repayment_amount = LiquidUsdt::from_str_in_dollar("10500").unwrap();
+        let collateral = LiquidBtc::from(Amount::from_btc(0.4).unwrap());
+        let current_price = LiquidUsdt::from_str_in_dollar("40000").unwrap();
+        let ltv = calculate_ltv(repayment_amount, collateral, current_price).unwrap();
+
+        assert_eq!(ltv, dec!(0.65625))
+    }
+
+    #[test]
+    fn given_loan_request_acceptable_then_dont_error() {
+        let request_price = LiquidUsdt::from_str_in_dollar("40000").unwrap();
+        let current_price = LiquidUsdt::from_str_in_dollar("39603.96039604").unwrap();
+        let price_fluctuation_interval = (dec!(0.90), dec!(1.01));
+        let request_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let min_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let max_principal = LiquidUsdt::from_str_in_dollar("10000").unwrap();
+        let request_ltv = dec!(0.8);
+        let max_ltv = dec!(0.8);
+
+        validate_loan_is_acceptable(
+            request_price,
+            current_price,
+            price_fluctuation_interval,
+            request_principal,
+            min_principal,
+            max_principal,
+            request_ltv,
+            max_ltv,
+        )
+        .unwrap()
+        .unwrap();
+    }
+
+    #[test]
+    fn given_loan_request_and_price_drop_lower_then_fluctuation_then_error() {
+        let request_price = LiquidUsdt::from_str_in_dollar("40000").unwrap();
+        let price_fluctuation_interval = (dec!(0.90), dec!(1.01));
+        let request_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let min_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let max_principal = LiquidUsdt::from_str_in_dollar("10000").unwrap();
+        let request_ltv = dec!(0.8);
+        let max_ltv = dec!(0.8);
+
+        let current_price = LiquidUsdt::from_str_in_dollar("39603.96039603").unwrap();
+        let error = validate_loan_is_acceptable(
+            request_price,
+            current_price,
+            price_fluctuation_interval,
+            request_principal,
+            min_principal,
+            max_principal,
+            request_ltv,
+            max_ltv,
+        )
+        .unwrap()
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            LoanValidationError::PriceNotAcceptable {
+                request_price,
+                current_price
+            }
+        )
+    }
+
+    #[test]
+    fn given_loan_request_and_price_raise_higher_then_fluctuation_then_error() {
+        let request_price = LiquidUsdt::from_str_in_dollar("40000").unwrap();
+        let price_fluctuation_interval = (dec!(0.90), dec!(1.01));
+        let request_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let min_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let max_principal = LiquidUsdt::from_str_in_dollar("10000").unwrap();
+        let request_ltv = dec!(0.8);
+        let max_ltv = dec!(0.8);
+
+        let current_price = LiquidUsdt::from_str_in_dollar("44444.44444445").unwrap();
+        let error = validate_loan_is_acceptable(
+            request_price,
+            current_price,
+            price_fluctuation_interval,
+            request_principal,
+            min_principal,
+            max_principal,
+            request_ltv,
+            max_ltv,
+        )
+        .unwrap()
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            LoanValidationError::PriceNotAcceptable {
+                request_price,
+                current_price
+            }
+        )
+    }
+
+    #[test]
+    fn given_loan_request_with_principal_lower_min_then_error() {
+        let request_price = LiquidUsdt::from_str_in_dollar("40000").unwrap();
+        let current_price = LiquidUsdt::from_str_in_dollar("40000").unwrap();
+        let price_fluctuation_interval = (dec!(0.90), dec!(1.01));
+        let min_principal = LiquidUsdt::from_str_in_dollar("1000").unwrap();
+        let max_principal = LiquidUsdt::from_str_in_dollar("10000").unwrap();
+        let request_ltv = dec!(0.8);
+        let max_ltv = dec!(0.8);
+
+        let request_principal = LiquidUsdt::from_str_in_dollar("999.99999999").unwrap();
+        let error = validate_loan_is_acceptable(
+            request_price,
+            current_price,
+            price_fluctuation_interval,
+            request_principal,
+            min_principal,
+            max_principal,
+            request_ltv,
+            max_ltv,
+        )
+        .unwrap()
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            LoanValidationError::PrincipalBelowMin {
+                request_principal,
+                min_principal
+            }
         )
     }
 }

--- a/bobtimus/src/loan.rs
+++ b/bobtimus/src/loan.rs
@@ -406,7 +406,7 @@ fn validate_loan_is_acceptable(
     // If no collateraliztion thresholds are specified in the offer then we ignore this check and only check for LTV
     // Note that as a safety net the LTV still outweights the collateralization check.
     if !collateralizations.is_empty() {
-        let mut sorted_collateralizations = collateralizations.clone();
+        let mut sorted_collateralizations = collateralizations;
         sorted_collateralizations.sort_by(|a, b| a.collateralization.cmp(&b.collateralization));
         let min_collateralization = sorted_collateralizations
             .first()
@@ -428,7 +428,7 @@ fn validate_loan_is_acceptable(
         }));
     }
 
-    if terms.iter().find(|a| a.days == request_term).is_none() {
+    if !terms.iter().any(|a| a.days == request_term) {
         return Ok(Err(LoanValidationError::TermNotAllowed {
             term: request_term,
         }));
@@ -845,7 +845,7 @@ mod tests {
             .with_request_collateralization(request_collateralization)
             .with_collateralizations(collateralizations);
 
-        validate_loan_is_acceptable(loan_validation_params.clone())
+        validate_loan_is_acceptable(loan_validation_params)
             .unwrap()
             .unwrap();
     }

--- a/extension/src/background-proxy.ts
+++ b/extension/src/background-proxy.ts
@@ -106,8 +106,3 @@ export async function getPastTransactions(): Promise<Txid[]> {
     // @ts-ignore
     return proxy.getPastTransactions();
 }
-
-export async function getBlockHeight(): Promise<number> {
-    // @ts-ignore
-    return proxy.getBlockHeight();
-}

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -10,7 +10,6 @@ import {
     extractTrade,
     getAddress,
     getBalances,
-    getBlockHeight,
     getOpenLoans,
     getPastTransactions,
     loadLoanBackup,
@@ -231,11 +230,6 @@ window.bip39SeedWords = async (): string => {
 // @ts-ignore
 window.createWalletFromBip39 = async (seed_words: string, password: string) => {
     return createNewBip39Wallet(walletName, seed_words, password);
-};
-
-// @ts-ignore
-window.getBlockHeight = async () => {
-    return getBlockHeight();
 };
 
 function updateBadge() {

--- a/extension/src/components/ConfirmLoanWizard.tsx
+++ b/extension/src/components/ConfirmLoanWizard.tsx
@@ -14,18 +14,15 @@ import {
     VStack,
 } from "@chakra-ui/react";
 import { Step, Steps, useSteps } from "chakra-ui-steps";
-import Debug from "debug";
 import moment from "moment";
 import React, { useState } from "react";
 import { useAsync } from "react-async";
 import { FiCheck, FiClipboard, FiExternalLink } from "react-icons/all";
 import { browser } from "webextension-polyfill-ts";
-import { confirmLoan, createLoanBackup, getBlockHeight, rejectLoan, signLoan } from "../background-proxy";
+import { confirmLoan, createLoanBackup, rejectLoan, signLoan } from "../background-proxy";
 import { LoanToSign, USDT_TICKER } from "../models";
 import YouSwapItem from "./SwapItem";
 import Usdt from "./tether.svg";
-
-const debug = Debug("confirmloan");
 
 interface ConfirmLoanWizardProps {
     onCancel: () => void;
@@ -197,19 +194,13 @@ function ConfirmLoan(
 ) {
     let { details: { collateral, principal, principalRepayment, term } } = loanToSign;
 
-    let { data: blockHeight, reload: reloadBlockHeight } = useAsync({
-        promiseFn: getBlockHeight,
-        onReject: (e) => debug("Failed to fetch block height %s", e),
-    });
-
+    let [timestamp, setTimestamp] = useState(Math.floor(Date.now() / 1000));
     useInterval(() => {
-        reloadBlockHeight();
+        setTimestamp(Math.floor(Date.now() / 1000));
     }, 6000); // 1 min
 
-    // format the time nicely into something like : `in 13 hours` or `in 1 month`.
-    // block-height and loan-term are in "blocktime" ^= minutes
-    const deadline = blockHeight && term
-        ? moment().add(Math.abs(blockHeight - term), "minutes").fromNow()
+    const deadline = timestamp && term
+        ? moment().add(Math.abs(timestamp - term), "seconds").fromNow()
         : null;
 
     return (<Box>
@@ -245,7 +236,7 @@ function ConfirmLoan(
         <Box w="100%">
             <Flex>
                 <Box h="40px" p="1">
-                    <Text>Loan term: {term} block-height {deadline ? "(due " + deadline + ")" : ""}</Text>
+                    <Text>Loan term: {timestamp} timestamp {deadline ? "(due " + deadline + ")" : ""}</Text>
                 </Box>
             </Flex>
         </Box>

--- a/extension/src/wasmProxy.ts
+++ b/extension/src/wasmProxy.ts
@@ -165,10 +165,3 @@ export async function createNewBip39Wallet(name: string, seedWords: string, pass
     debug("create_new_bip39_wallet");
     return create_new_bip39_wallet(name, seedWords, password);
 }
-
-export async function getBlockHeight(): Promise<string> {
-    const { get_block_height } = await import("./wallet");
-
-    debug("getBlockHeight");
-    return get_block_height();
-}

--- a/extension/wallet/Cargo.toml
+++ b/extension/wallet/Cargo.toml
@@ -13,7 +13,7 @@ default = ["console_error_panic_hook"]
 [dependencies]
 aes-gcm-siv = { version = "0.9", features = ["std"] }
 anyhow = "1"
-baru = { git = "https://github.com/da-kami/baru", branch = "lender-decides-timelock" }
+baru = "0.3"
 bip32 = { version = "0.2", features = ["secp256k1-ffi", "bip39"], default-features = false }
 coin_selection = { path = "../../coin_selection" }
 conquer-once = "0.3"

--- a/extension/wallet/src/esplora.rs
+++ b/extension/wallet/src/esplora.rs
@@ -155,23 +155,6 @@ pub async fn get_fee_estimates() -> Result<FeeEstimatesResponse> {
     Ok(fee_estimates)
 }
 
-pub async fn get_block_height() -> Result<u32> {
-    let esplora_url = {
-        let guard = ESPLORA_API_URL.lock().expect_throw("can get lock");
-        guard.clone()
-    };
-    let esplora_url = esplora_url.join("/blocks/tip/height")?;
-
-    let latest_block_height = reqwest::get(esplora_url.clone())
-        .await
-        .with_context(|| format!("failed to GET {}", esplora_url))?
-        .json()
-        .await
-        .context("failed to deserialize latest block height")?;
-
-    Ok(latest_block_height)
-}
-
 /// The response object for the `/fee-estimates` endpoint.
 ///
 /// The key is the confirmation target (in number of blocks) and the value is the estimated feerate (in sat/vB).

--- a/extension/wallet/src/lib.rs
+++ b/extension/wallet/src/lib.rs
@@ -143,15 +143,6 @@ pub async fn wallet_status(name: String) -> Result<JsValue, JsValue> {
     Ok(status)
 }
 
-/// Retrieve the latest block height from Esplora
-#[wasm_bindgen]
-pub async fn get_block_height() -> Result<JsValue, JsValue> {
-    let latest_block_height = map_err_from_anyhow!(esplora::get_block_height().await)?;
-    let latest_block_height = map_err_from_anyhow!(JsValue::from_serde(&latest_block_height))?;
-
-    Ok(latest_block_height)
-}
-
 /// Get an address for the wallet with the given name.
 ///
 /// Fails if the wallet is currently not loaded.

--- a/extension/wallet/src/wallet/make_loan_request.rs
+++ b/extension/wallet/src/wallet/make_loan_request.rs
@@ -126,6 +126,8 @@ pub async fn make_loan_request(
         )
         .map_err(Error::Save)?;
 
+    // TODO: Fix, use new API here
+    #[allow(deprecated)]
     Ok(borrower_state_0.loan_request())
 }
 

--- a/waves/src/App.test.tsx
+++ b/waves/src/App.test.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { Asset, reducer, State } from "./App";
+import { LoanOffer } from "./Bobtimus";
 import calculateBetaAmount from "./calculateBetaAmount";
 
-const defaultLoanOffer = {
+const defaultLoanOffer: LoanOffer = {
     rate: {
         ask: 20000,
         bid: 20000,
@@ -11,10 +12,14 @@ const defaultLoanOffer = {
     min_principal: 100,
     max_principal: 10000,
     max_ltv: 0.8,
-    interest: [{
-        term: 30,
-        interest_rate: 0.15,
+    base_interest_rate: 0.15,
+    terms: [{
+        days: 30,
+        interest_mod: 0.01,
+    }],
+    collateralizations: [{
         collateralization: 1.5,
+        interest_mod: -0.02,
     }],
 };
 
@@ -34,6 +39,8 @@ const defaultState: State = {
     borrow: {
         principalAmount: "1000",
         loanTermInDays: 43200, // 30 days in min
+        collateralization: 1.5,
+
         loanOffer: defaultLoanOffer,
     },
     wallet: {
@@ -222,6 +229,7 @@ test("update loan offer logic", () => {
             loanTermInDays: 0,
             principalAmount: "0",
             loanOffer: null,
+            collateralization: 0,
         },
     };
 
@@ -233,4 +241,5 @@ test("update loan offer logic", () => {
     expect(newState.borrow.loanOffer).toBe(defaultLoanOffer);
     expect(newState.borrow.principalAmount).toBe("100");
     expect(newState.borrow.loanTermInDays).toBe(30);
+    expect(newState.borrow.collateralization).toBe(1.5);
 });

--- a/waves/src/App.tsx
+++ b/waves/src/App.tsx
@@ -49,6 +49,7 @@ export interface BorrowState {
     // user can select
     loanTermInDays: number;
     principalAmount: string;
+    collateralization: number;
 
     // from Bobtimus
     loanOffer: LoanOffer | null;
@@ -109,6 +110,7 @@ const initialState: State = {
         principalAmount: "0.0",
         loanTermInDays: 0,
         loanOffer: null,
+        collateralization: 0,
     },
     wallet: {
         balance: {
@@ -224,7 +226,8 @@ export function reducer(state: State = initialState, action: Action) {
             // TODO: We currently always overwrite upon a new loan offer
             //  This will have to be adapted once we refresh loan offers.
             const principalAmount = action.value.min_principal.toString();
-            const loanTermInDays = action.value.interest[0].term;
+            const loanTermInDays = action.value.terms[0].days;
+            const collateralization = action.value.collateralizations[0].collateralization;
 
             return {
                 ...state,
@@ -232,6 +235,7 @@ export function reducer(state: State = initialState, action: Action) {
                     ...state.borrow,
                     principalAmount,
                     loanTermInDays,
+                    collateralization,
                     loanOffer: action.value,
                 },
             };

--- a/waves/src/Bobtimus.tsx
+++ b/waves/src/Bobtimus.tsx
@@ -4,6 +4,7 @@ import { SSEProvider } from "react-hooks-sse";
 import { CreateSwapPayload, LoanRequestPayload, OutPoint } from "./waves-provider/wavesProvider";
 
 const debug = Debug("bobtimus");
+const BTC_SATS = 100000000;
 
 export async function fundAddress(address: string): Promise<any> {
     await fetch("/api/faucet/" + address, {
@@ -24,10 +25,25 @@ export interface Rate {
     bid: number; // sat
 }
 
-export interface Interest {
-    term: number;
-    interest_rate: number; // percentage, decimal represented as float
-    collateralization: number; // percentage, decimal represented as float
+export interface Term {
+    days: number;
+    // percentage, decimal represented as float
+    // example:
+    // 0.01 => add 0.01 to base interest
+    // -0.01 => subtract 0.01 from base interest
+    interest_mod: number;
+}
+
+export interface Collateralization {
+    // percentage, decimal represented as float
+    // example:
+    // 1.5 => 150%
+    collateralization: number;
+    // percentage, decimal represented as float
+    // example:
+    // 0.01 => add 0.01 to base interest
+    // -0.01 => subtract 0.01 from base interest
+    interest_mod: number;
 }
 
 export interface LoanOffer {
@@ -35,14 +51,19 @@ export interface LoanOffer {
     fee_sats_per_vbyte: number;
     min_principal: number; // sat
     max_principal: number; // sat
-    max_ltv: number; // percentage, decimal represented as float
-    interest: Interest[];
+    // percentage, decimal represented as float
+    // 0.8 => 80%
+    max_ltv: number;
+    base_interest_rate: number;
+    terms: Term[];
+    collateralizations: Collateralization[];
 }
 
 export interface LoanRequest {
+    principal_amount: number;
     collateral_amount: number;
     collateral_inputs: { txin: OutPoint; original_txout: any; blinding_key: string }[];
-    fee_sats_per_vbyte: number;
+    collateralization: number;
     borrower_pk: string;
     borrower_address: string;
 
@@ -67,13 +88,23 @@ export async function getLoanOffer(): Promise<LoanOffer> {
     return await res.json();
 }
 
-export async function postLoanRequest(walletParams: LoanRequestPayload, termInDays: number) {
+export async function postLoanRequest(
+    walletParams: LoanRequestPayload,
+    termInDays: number,
+    collateralization: number,
+    principal: number,
+) {
+    // TODO: Make sure to convert all the other amounts to sats as well
+    // convert principal to sats
+    let principal_sats = principal * BTC_SATS;
+
     let loanRequest: LoanRequest = {
+        collateralization: collateralization,
+        principal_amount: principal_sats,
         borrower_address: walletParams.borrower_address,
         borrower_pk: walletParams.borrower_pk,
         collateral_amount: walletParams.collateral_amount,
         collateral_inputs: walletParams.collateral_inputs,
-        fee_sats_per_vbyte: walletParams.fee_sats_per_vbyte,
         term: termInDays,
     };
 

--- a/waves/src/Borrow.tsx
+++ b/waves/src/Borrow.tsx
@@ -56,8 +56,9 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
     // TODO: Let the user define the collateral amount that is within Bobtimus' LTV bounds
     let interestAmount = principalAmount * interestRate;
     let repaymentAmount = principalAmount + interestAmount;
-    // TODO: Is the ask price actually correct here?
-    let collateralAmount = (repaymentAmount * state.collateralization) * (1 / rate.ask);
+
+    // The bid price is used so the lender is covered under the assumption of selling the asset
+    let collateralAmount = (repaymentAmount * state.collateralization) / rate.bid;
 
     let { run: takeLoan, isLoading: isTakingLoan } = useAsync({
         deferFn: async () => {


### PR DESCRIPTION
Lender now includes the loan calculations and the validation of the loan.
I clicked it through and it looks sane :)

To be done in follow ups:

- Send **all** amounts in sats and do conversion on UI side (did not tackle all amounts yet)
- Validation step for the loan term
- Upgrade the UI so the borrower can select values