### PR TITLE
Use LTV ratio instead of collateralization

### DIFF
--- a/bobtimus/src/lib.rs
+++ b/bobtimus/src/lib.rs
@@ -44,7 +44,7 @@ pub mod problem;
 pub mod schema;
 
 use crate::loan::{
-    loan_calculation_and_validation, Collateralization, LoanOffer, LoanRequest, Term, ValidatedLoan,
+    loan_calculation_and_validation, LoanOffer, LoanRequest, Ltv, Term, ValidatedLoan,
 };
 pub use amounts::*;
 use elements::bitcoin::PublicKey;
@@ -304,16 +304,7 @@ where
                     interest_mod: Decimal::ZERO,
                 },
             ],
-            collateralizations: vec![
-                Collateralization {
-                    collateralization: dec!(1.5),
-                    interest_mod: Decimal::ZERO,
-                },
-                Collateralization {
-                    collateralization: dec!(2.0),
-                    interest_mod: Decimal::ZERO,
-                },
-            ],
+            initial_ltvs: vec![Ltv { ltv: dec!(0.5) }, Ltv { ltv: dec!(0.7) }],
         }
     }
 

--- a/e2e_tests/e2e_test_setup.sh
+++ b/e2e_tests/e2e_test_setup.sh
@@ -12,7 +12,7 @@ while getopts "CS" o; do
             then
                 echo "Clearing docker compose data"
                 cd nigiri
-                docker-compose down
+                docker compose down
                 rm -rf liquid-config/liquidregtest
                 cd ..
             else
@@ -21,7 +21,7 @@ while getopts "CS" o; do
             ;;
         S)
             echo "Starting docker containers"
-            docker-compose -f ./nigiri/docker-compose.yml up -d
+            docker compose -f ./nigiri/docker-compose.yml up -d
             ;;
         *)
             usage
@@ -73,7 +73,7 @@ echo "Bitcoin Asset ID: "$btc_asset_id
             start \
             --http 127.0.0.1:3030 \
             --elementsd http://admin1:123@localhost:18884 \
-            --usdt $usdt_asset_id > e2e_tests/bobtimus.log 2>&1 &
+            --usdt 2dcf5a8834645654911964ec3602426fd3b9b4017554d3f9c19403e7fc1411d3 > e2e_tests/bobtimus.log 2>&1 &
 )
 
 # give bobtimus time to start:

--- a/waves/src/App.test.tsx
+++ b/waves/src/App.test.tsx
@@ -17,9 +17,8 @@ const defaultLoanOffer: LoanOffer = {
         days: 30,
         interest_mod: 0.01,
     }],
-    collateralizations: [{
-        collateralization: 1.5,
-        interest_mod: -0.02,
+    initial_ltvs: [{
+        ltv: 0.5,
     }],
 };
 
@@ -39,7 +38,7 @@ const defaultState: State = {
     borrow: {
         principalAmount: "1000",
         loanTermInDays: 43200, // 30 days in min
-        collateralization: 1.5,
+        ltv: 0.5,
 
         loanOffer: defaultLoanOffer,
     },
@@ -229,7 +228,7 @@ test("update loan offer logic", () => {
             loanTermInDays: 0,
             principalAmount: "0",
             loanOffer: null,
-            collateralization: 0,
+            ltv: 0,
         },
     };
 
@@ -241,5 +240,5 @@ test("update loan offer logic", () => {
     expect(newState.borrow.loanOffer).toBe(defaultLoanOffer);
     expect(newState.borrow.principalAmount).toBe("100");
     expect(newState.borrow.loanTermInDays).toBe(30);
-    expect(newState.borrow.collateralization).toBe(1.5);
+    expect(newState.borrow.ltv).toBe(0.5);
 });

--- a/waves/src/App.tsx
+++ b/waves/src/App.tsx
@@ -49,7 +49,7 @@ export interface BorrowState {
     // user can select
     loanTermInDays: number;
     principalAmount: string;
-    collateralization: number;
+    ltv: number;
 
     // from Bobtimus
     loanOffer: LoanOffer | null;
@@ -110,7 +110,7 @@ const initialState: State = {
         principalAmount: "0.0",
         loanTermInDays: 0,
         loanOffer: null,
-        collateralization: 0,
+        ltv: 0.5,
     },
     wallet: {
         balance: {
@@ -227,7 +227,8 @@ export function reducer(state: State = initialState, action: Action) {
             //  This will have to be adapted once we refresh loan offers.
             const principalAmount = action.value.min_principal.toString();
             const loanTermInDays = action.value.terms[0].days;
-            const collateralization = action.value.collateralizations[0].collateralization;
+            debug("%s", JSON.stringify(action.value));
+            const ltv = action.value.initial_ltvs[0].ltv;
 
             return {
                 ...state,
@@ -235,7 +236,7 @@ export function reducer(state: State = initialState, action: Action) {
                     ...state.borrow,
                     principalAmount,
                     loanTermInDays,
-                    collateralization,
+                    ltv,
                     loanOffer: action.value,
                 },
             };

--- a/waves/src/Bobtimus.tsx
+++ b/waves/src/Bobtimus.tsx
@@ -34,16 +34,11 @@ export interface Term {
     interest_mod: number;
 }
 
-export interface Collateralization {
+export interface Ltv {
     // percentage, decimal represented as float
     // example:
-    // 1.5 => 150%
-    collateralization: number;
-    // percentage, decimal represented as float
-    // example:
-    // 0.01 => add 0.01 to base interest
-    // -0.01 => subtract 0.01 from base interest
-    interest_mod: number;
+    // 0.5 => 50%
+    ltv: number;
 }
 
 export interface LoanOffer {
@@ -56,14 +51,14 @@ export interface LoanOffer {
     max_ltv: number;
     base_interest_rate: number;
     terms: Term[];
-    collateralizations: Collateralization[];
+    initial_ltvs: Ltv[];
 }
 
 export interface LoanRequest {
     principal_amount: number;
     collateral_amount: number;
     collateral_inputs: { txin: OutPoint; original_txout: any; blinding_key: string }[];
-    collateralization: number;
+    ltv: number;
     borrower_pk: string;
     borrower_address: string;
 
@@ -91,7 +86,7 @@ export async function getLoanOffer(): Promise<LoanOffer> {
 export async function postLoanRequest(
     walletParams: LoanRequestPayload,
     termInDays: number,
-    collateralization: number,
+    requested_ltv: number,
     principal: number,
 ) {
     // TODO: Make sure to convert all the other amounts to sats as well
@@ -99,7 +94,7 @@ export async function postLoanRequest(
     let principal_sats = principal * BTC_SATS;
 
     let loanRequest: LoanRequest = {
-        collateralization: collateralization,
+        ltv: requested_ltv,
         principal_amount: principal_sats,
         borrower_address: walletParams.borrower_address,
         borrower_pk: walletParams.borrower_pk,

--- a/waves/src/Borrow.tsx
+++ b/waves/src/Borrow.tsx
@@ -181,7 +181,7 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
                             />
                         </Box>
                     </Tooltip>
-                    <p>Collateral (for LTV of {state.ltv*100}%):</p>
+                    <p>Collateral (for LTV of {state.ltv * 100}%):</p>
                     <NumberInput
                         currency="₿"
                         value={collateralAmount}

--- a/waves/src/Borrow.tsx
+++ b/waves/src/Borrow.tsx
@@ -58,7 +58,7 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
     let repaymentAmount = principalAmount + interestAmount;
 
     // The bid price is used so the lender is covered under the assumption of selling the asset
-    let collateralAmount = (repaymentAmount * state.collateralization) / rate.bid;
+    let collateralAmount = (repaymentAmount / rate.bid) / state.ltv;
 
     let { run: takeLoan, isLoading: isTakingLoan } = useAsync({
         deferFn: async () => {
@@ -78,7 +78,7 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
                 let loanResponse = await postLoanRequest(
                     loanRequestWalletParams,
                     state.loanTermInDays,
-                    state.collateralization,
+                    state.ltv,
                     principalAmount,
                 );
                 debug(JSON.stringify(loanResponse));
@@ -181,7 +181,7 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
                             />
                         </Box>
                     </Tooltip>
-                    <p>Collateral:</p>
+                    <p>Collateral (for LTV of {state.ltv*100}%):</p>
                     <NumberInput
                         currency="₿"
                         value={collateralAmount}


### PR DESCRIPTION
Using LTV ratios instead of collateralization in percent is easier to calculate with due to the simple formula of :
`LTV = repayment_amount / (collateral * rate)`
With this formula alone we can compute if the user provided enough collateral or at what rate the loan will be liquidated given a max LTV ratio.

Signed-off-by: Philipp Hoenisch <philipp@hoenisch.at>