### PR TITLE
Display loan validation error details in the frontend

### DIFF
--- a/bobtimus/src/loan.rs
+++ b/bobtimus/src/loan.rs
@@ -313,7 +313,7 @@ fn calculate_ltv(
 }
 
 #[derive(Debug, PartialEq, thiserror::Error)]
-enum LoanValidationError {
+pub enum LoanValidationError {
     #[error(
         "The given price {request_price} is not acceptable with current price {current_price}"
     )]

--- a/waves/src/Borrow.tsx
+++ b/waves/src/Borrow.tsx
@@ -4,7 +4,7 @@ import React, { Dispatch } from "react";
 import { AsyncState, useAsync } from "react-async";
 import { useHistory } from "react-router-dom";
 import { Action, BorrowState, Rate } from "./App";
-import { getLoanOffer, postLoanFinalization, postLoanRequest } from "./Bobtimus";
+import { getLoanOffer, LoanError, postLoanFinalization, postLoanRequest } from "./Bobtimus";
 import NumberInput from "./components/NumberInput";
 import RateInfo from "./components/RateInfo";
 import WavesProvider from "./waves-provider";
@@ -89,15 +89,27 @@ function Borrow({ dispatch, state, rate, wavesProvider, walletStatusAsyncState }
                 // TODO: Add different page for loaned?
                 history.push(`/trade/swapped/${txid}`);
             } catch (e) {
-                const description = typeof e === "string" ? e : JSON.stringify(e);
+                if (e instanceof LoanError) {
+                    const description = e.description ? e.description : "";
 
-                toast({
-                    title: "Error",
-                    description,
-                    status: "error",
-                    duration: 5000,
-                    isClosable: true,
-                });
+                    toast({
+                        title: e.title,
+                        description,
+                        status: "error",
+                        duration: 10000,
+                        isClosable: true,
+                    });
+                } else {
+                    const description = typeof e === "string" ? e : JSON.stringify(e);
+
+                    toast({
+                        title: "Error",
+                        description,
+                        status: "error",
+                        duration: 5000,
+                        isClosable: true,
+                    });
+                }
             }
         },
     });


### PR DESCRIPTION
Define loan validation errors as RFC7807 error 400 (Bad Request) and publish error
message inside error field inside it.

Add support for displaying new error type inside Toast error box.

Addresses #246 (partially). 